### PR TITLE
Add support for running erc20 rollup which uses custom fee token

### DIFF
--- a/scripts/ethcommands.ts
+++ b/scripts/ethcommands.ts
@@ -1,7 +1,8 @@
 import { runStress } from "./stress";
-import { ethers } from "ethers";
+import { ContractFactory, ethers, Wallet } from "ethers";
 import * as consts from "./consts";
 import { namedAccount, namedAddress } from "./accounts";
+import * as ERC20PresetFixedSupplyArtifact from "@openzeppelin/contracts/build/contracts/ERC20PresetFixedSupply.json";
 import * as fs from "fs";
 const path = require("path");
 
@@ -75,6 +76,43 @@ export const bridgeFundsCommand = {
         await sleep(100)
       }
     }
+  },
+};
+
+export const createERC20Command = {
+  command: "create-erc20",
+  describe: "creates simple ERC20 on L1",
+  builder: {
+    deployerKey: {
+      string: true,
+      describe: "account (see general help)",
+      default: "funnel",
+    },
+    mintTo: {
+      string: true,
+      describe: "account (see general help)",
+      default: "funnel",
+    },
+  },
+  handler: async (argv: any) => {
+    console.log("create-erc20");
+
+    argv.provider = new ethers.providers.WebSocketProvider(argv.l1url);
+
+    const contractFactory = new ContractFactory(
+      ERC20PresetFixedSupplyArtifact.abi,
+      ERC20PresetFixedSupplyArtifact.bytecode,
+      new Wallet(
+        argv.deployerKey,
+        argv.provider
+      )
+    );
+    const contract = await contractFactory.deploy("AppTestToken", "APP", ethers.utils.parseEther("1000000000"), namedAccount(argv.mintTo).address);
+    await contract.deployTransaction.wait();
+
+    console.log("Contract deployed at address:", contract.address);
+
+    argv.provider.destroy();
   },
 };
 

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -10,6 +10,7 @@ import {
 } from "./accounts";
 import {
   bridgeFundsCommand,
+  createERC20Command,
   sendL1Command,
   sendL2Command,
   sendRPCCommand,
@@ -24,6 +25,7 @@ async function main() {
     })
     .options(stressOptions)
     .command(bridgeFundsCommand)
+    .command(createERC20Command)
     .command(sendL1Command)
     .command(sendL2Command)
     .command(sendRPCCommand)

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -7,6 +7,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@node-redis/client": "^1.0.4",
+    "@openzeppelin/contracts": "^4.9.2",
     "@types/node": "^17.0.22",
     "@types/yargs": "^17.0.10",
     "ethers": "^5.6.1",

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -4,7 +4,8 @@
       "module": "CommonJS",
       "strict": true,
       "esModuleInterop": true,
-      "moduleResolution": "node"
+      "moduleResolution": "node",
+      "resolveJsonModule": true
     },
     "files": ["index.ts"]
   }

--- a/scripts/yarn.lock
+++ b/scripts/yarn.lock
@@ -352,6 +352,11 @@
     redis-parser "3.0.0"
     yallist "4.0.0"
 
+"@openzeppelin/contracts@^4.9.2":
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.2.tgz#1cb2d5e4d3360141a17dbc45094a8cad6aac16c1"
+  integrity sha512-mO+y6JaqXjWeMh9glYVzVu8HYPGknAAnWyxTRhGeckOruyXQMNnlcW6w/Dx9ftLeIQk6N+ZJFuVmTwF7lEIFrg==
+
 "@types/node@^17.0.22":
   version "17.0.22"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.22.tgz#38b6c4b9b2f3ed9f2e376cce42a298fb2375251e"

--- a/test-node.bash
+++ b/test-node.bash
@@ -39,6 +39,7 @@ consensusclient=false
 redundantsequencers=0
 dev_build_nitro=false
 dev_build_blockscout=false
+erc20rollup=false
 batchposters=1
 devprivkey=b6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659
 l1chainid=1337
@@ -98,6 +99,10 @@ while [[ $# -gt 0 ]]; do
             detach=true
             shift
             ;;
+        --erc20-rollup)
+            erc20rollup=true
+            shift
+            ;;
         --batchposters)
             batchposters=$2
             if ! [[ $batchposters =~ [0-3] ]] ; then
@@ -131,6 +136,7 @@ while [[ $# -gt 0 ]]; do
             echo --init:            remove all data, rebuild, deploy new rollup
             echo --pos:             l1 is a proof-of-stake chain \(using prysm for consensus\)
             echo --validate:        heavy computation, validating all blocks in WASM
+            echo --erc20rollup:     deploys rollup in erc20 mode where token is used as L2 native currency
             echo --batchposters:    batch posters [0-3]
             echo --redundantsequencers redundant sequencers [0-3]
             echo --detach:          detach from nodes after running them
@@ -281,10 +287,15 @@ if $force_init; then
     docker-compose run scripts send-l1 --ethamount 1000 --to user_l1user --wait
     docker-compose run scripts send-l1 --ethamount 0.0001 --from user_l1user --to user_l1user_b --wait --delay 500 --times 500 > /dev/null &
 
-    echo == Deploying L2
     sequenceraddress=`docker-compose run scripts print-address --account sequencer | tail -n 1 | tr -d '\r\n'`
-
-    docker-compose run --entrypoint /usr/local/bin/deploy poster --l1conn ws://geth:8546 --l1keystore /home/user/l1keystore --sequencerAddress $sequenceraddress --ownerAddress $sequenceraddress --l1DeployAccount $sequenceraddress --l1deployment /config/deployment.json --authorizevalidators 10 --wasmrootpath /home/user/target/machines --l1chainid=$l1chainid
+    deployL2Command="docker-compose run --entrypoint /usr/local/bin/deploy poster --l1conn ws://geth:8546 --l1keystore /home/user/l1keystore --sequencerAddress $sequenceraddress --ownerAddress $sequenceraddress --l1DeployAccount $sequenceraddress --l1deployment /config/deployment.json --authorizevalidators 10 --wasmrootpath /home/user/target/machines --l1chainid=$l1chainid"
+    if $erc20rollup; then
+        echo == Deploying custom fee token
+        nativeTokenAddress=`docker-compose run testnode-scripts create-erc20 --deployerKey $devprivkey --mintTo user_l1user | tail -n 1 | awk '{ print $NF }'`
+        deployL2Command+=" --nativeERC20TokenAddress $nativeTokenAddress"
+    fi
+    echo == Deploying L2
+    eval $deployL2Command
 
     echo == Writing configs
     docker-compose run scripts write-config
@@ -294,7 +305,9 @@ if $force_init; then
 
     echo == Funding l2 funnel
     docker-compose up -d $INITIAL_SEQ_NODES
-    docker-compose run scripts bridge-funds --ethamount 100000 --wait
+    if ! $erc20rollup; then
+        docker-compose run scripts bridge-funds --ethamount 100000 --wait
+    fi
 
     if $tokenbridge; then
         echo == Deploying token bridge


### PR DESCRIPTION
(Moved from PR in `nitro` repo)
Adds support in `test-node.bash` to quickly spin up ERC20-based rollup - flag `--erc20-rollup` should be provided (without an address). Test script will then create ERC20 token and configure it as rollup's native token. Address of the new token will be written among other rollup's parameters in json config file as native-erc20-token. Ie.` ./test-node.bash --init --dev --erc20-rollup --no-tokenbridge`