### PR TITLE
Add support for running erc20 rollup which uses custom fee token

### DIFF
--- a/scripts/ethcommands.ts
+++ b/scripts/ethcommands.ts
@@ -2,6 +2,7 @@ import { runStress } from "./stress";
 import { ContractFactory, ethers, Wallet } from "ethers";
 import * as consts from "./consts";
 import { namedAccount, namedAddress } from "./accounts";
+import * as ERC20PresetFixedSupplyArtifact from "@openzeppelin/contracts/build/contracts/ERC20PresetFixedSupply.json";
 import * as fs from "fs";
 const path = require("path");
 

--- a/scripts/ethcommands.ts
+++ b/scripts/ethcommands.ts
@@ -1,5 +1,5 @@
 import { runStress } from "./stress";
-import { ethers } from "ethers";
+import { ContractFactory, ethers, Wallet } from "ethers";
 import * as consts from "./consts";
 import { namedAccount, namedAddress } from "./accounts";
 import * as fs from "fs";
@@ -115,6 +115,44 @@ export const bridgeToL3Command = {
     await bridgeFunds(argv, argv.l2url, argv.l3url, inboxAddr)
   },
 };
+
+export const createERC20Command = {
+  command: "create-erc20",
+  describe: "creates simple ERC20 on L1",
+  builder: {
+    deployerKey: {
+      string: true,
+      describe: "account (see general help)",
+      default: "funnel",
+    },
+    mintTo: {
+      string: true,
+      describe: "account (see general help)",
+      default: "funnel",
+    },
+  },
+  handler: async (argv: any) => {
+    console.log("create-erc20");
+
+    argv.provider = new ethers.providers.WebSocketProvider(argv.l1url);
+
+    const contractFactory = new ContractFactory(
+      ERC20PresetFixedSupplyArtifact.abi,
+      ERC20PresetFixedSupplyArtifact.bytecode,
+      new Wallet(
+        argv.deployerKey,
+        argv.provider
+      )
+    );
+    const contract = await contractFactory.deploy("AppTestToken", "APP", ethers.utils.parseEther("1000000000"), namedAccount(argv.mintTo).address);
+    await contract.deployTransaction.wait();
+
+    console.log("Contract deployed at address:", contract.address);
+
+    argv.provider.destroy();
+  },
+};
+
 
 export const sendL1Command = {
   command: "send-l1",

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -30,6 +30,7 @@ async function main() {
     .options(stressOptions)
     .command(bridgeFundsCommand)
     .command(bridgeToL3Command)
+    .command(createERC20Command)
     .command(sendL1Command)
     .command(sendL2Command)
     .command(sendL3Command)

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -11,6 +11,7 @@ import {
 import {
   bridgeFundsCommand,
   bridgeToL3Command,
+  createERC20Command,
   sendL1Command,
   sendL2Command,
   sendL3Command,

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -7,6 +7,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@node-redis/client": "^1.0.4",
+    "@openzeppelin/contracts": "^4.9.3",
     "@types/node": "^17.0.22",
     "@types/yargs": "^17.0.10",
     "ethers": "^5.6.1",

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -4,7 +4,8 @@
       "module": "CommonJS",
       "strict": true,
       "esModuleInterop": true,
-      "moduleResolution": "node"
+      "moduleResolution": "node",
+      "resolveJsonModule": true
     },
     "files": ["index.ts"]
   }

--- a/scripts/yarn.lock
+++ b/scripts/yarn.lock
@@ -352,6 +352,11 @@
     redis-parser "3.0.0"
     yallist "4.0.0"
 
+"@openzeppelin/contracts@^4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.3.tgz#00d7a8cf35a475b160b3f0293a6403c511099364"
+  integrity sha512-He3LieZ1pP2TNt5JbkPA4PNT9WC3gOTOlDcFGJW4Le4QKqwmiNJCRt44APfxMxvq7OugU/cqYuPcSBzOw38DAg==
+
 "@types/node@^17.0.22":
   version "17.0.22"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.22.tgz#38b6c4b9b2f3ed9f2e376cce42a298fb2375251e"

--- a/test-node.bash
+++ b/test-node.bash
@@ -40,6 +40,7 @@ consensusclient=false
 redundantsequencers=0
 dev_build_nitro=false
 dev_build_blockscout=false
+customFeeToken=false
 batchposters=1
 devprivkey=b6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659
 l1chainid=1337
@@ -99,6 +100,10 @@ while [[ $# -gt 0 ]]; do
             detach=true
             shift
             ;;
+        --fee-token)
+            customFeeToken=true
+            shift
+            ;;
         --batchposters)
             batchposters=$2
             if ! [[ $batchposters =~ [0-3] ]] ; then
@@ -136,6 +141,7 @@ while [[ $# -gt 0 ]]; do
             echo --init:            remove all data, rebuild, deploy new rollup
             echo --pos:             l1 is a proof-of-stake chain \(using prysm for consensus\)
             echo --validate:        heavy computation, validating all blocks in WASM
+            echo --fee-token:       chain is set up to use custom fee token
             echo --batchposters:    batch posters [0-3]
             echo --redundantsequencers redundant sequencers [0-3]
             echo --detach:          detach from nodes after running them
@@ -300,11 +306,18 @@ if $force_init; then
     echo == Writing l2 chain config
     docker-compose run scripts write-l2-chain-config
 
-    echo == Deploying L2
     sequenceraddress=`docker-compose run scripts print-address --account sequencer | tail -n 1 | tr -d '\r\n'`
 
-    docker-compose run --entrypoint /usr/local/bin/deploy poster --l1conn ws://geth:8546 --l1keystore /home/user/l1keystore --sequencerAddress $sequenceraddress --ownerAddress $sequenceraddress --l1DeployAccount $sequenceraddress --l1deployment /config/deployment.json --authorizevalidators 10 --wasmrootpath /home/user/target/machines --l1chainid=$l1chainid --l2chainconfig /config/l2_chain_config.json --l2chainname arb-dev-test --l2chaininfo /config/deployed_chain_info.json
+    deployL2Command="docker-compose run --entrypoint /usr/local/bin/deploy poster --l1conn ws://geth:8546 --l1keystore /home/user/l1keystore --sequencerAddress $sequenceraddress --ownerAddress $sequenceraddress --l1DeployAccount $sequenceraddress --l1deployment /config/deployment.json --authorizevalidators 10 --wasmrootpath /home/user/target/machines --l1chainid=$l1chainid --l2chainconfig /config/l2_chain_config.json --l2chainname arb-dev-test --l2chaininfo /config/deployed_chain_info.json"
+    if $customFeeToken; then
+        echo == Deploying custom fee token
+        nativeTokenAddress=`docker-compose run testnode-scripts create-erc20 --deployerKey $devprivkey --mintTo user_l1user | tail -n 1 | awk '{ print $NF }'`
+        deployL2Command+=" --nativeERC20TokenAddress $nativeTokenAddress"
+    fi
+    echo == Deploying L2
+    eval $deployL2Command
     docker-compose run --entrypoint sh poster -c "jq [.[]] /config/deployed_chain_info.json > /config/l2_chain_info.json"
+
     echo == Writing configs
     docker-compose run scripts write-config
 
@@ -313,7 +326,9 @@ if $force_init; then
 
     echo == Funding l2 funnel
     docker-compose up -d $INITIAL_SEQ_NODES
-    docker-compose run scripts bridge-funds --ethamount 100000 --wait
+    if ! $customFeeToken; then
+        docker-compose run scripts bridge-funds --ethamount 100000 --wait
+    fi
 
     if $tokenbridge; then
         echo == Deploying token bridge

--- a/test-node.bash
+++ b/test-node.bash
@@ -311,7 +311,7 @@ if $force_init; then
     deployL2Command="docker-compose run --entrypoint /usr/local/bin/deploy poster --l1conn ws://geth:8546 --l1keystore /home/user/l1keystore --sequencerAddress $sequenceraddress --ownerAddress $sequenceraddress --l1DeployAccount $sequenceraddress --l1deployment /config/deployment.json --authorizevalidators 10 --wasmrootpath /home/user/target/machines --l1chainid=$l1chainid --l2chainconfig /config/l2_chain_config.json --l2chainname arb-dev-test --l2chaininfo /config/deployed_chain_info.json"
     if $customFeeToken; then
         echo == Deploying custom fee token
-        nativeTokenAddress=`docker-compose run testnode-scripts create-erc20 --deployerKey $devprivkey --mintTo user_l1user | tail -n 1 | awk '{ print $NF }'`
+        nativeTokenAddress=`docker-compose run scripts create-erc20 --deployerKey $devprivkey --mintTo user_l1user | tail -n 1 | awk '{ print $NF }'`
         deployL2Command+=" --nativeERC20TokenAddress $nativeTokenAddress"
     fi
     echo == Deploying L2


### PR DESCRIPTION
Adds support in `test-node.bash` to quickly spin up ERC20-based rollup - flag `--fee-token` should be provided (without an address). Test script will then create basic ERC20 token and configure it as rollup's native fee token. 

It can be used like this:  `./test-node.bash --init --dev --fee-token --no-tokenbridge`