### PR TITLE
Bump nitro image

### DIFF
--- a/test-node.bash
+++ b/test-node.bash
@@ -2,7 +2,7 @@
 
 set -e
 
-NITRO_NODE_VERSION=offchainlabs/nitro-node:v2.1.1-e9d8842-dev
+NITRO_NODE_VERSION=offchainlabs/nitro-node:v2.2.0-alpha.2-0230f42-dev
 BLOCKSCOUT_VERSION=offchainlabs/blockscout:v1.0.0-c8db5b1
 
 mydir=`dirname $0`


### PR DESCRIPTION
Bump nitro image to 2.2.0-X. 

It's needed so that [ERC20 based rollup](https://github.com/OffchainLabs/nitro/pull/1879) support is included. 