### PR TITLE
Update geth image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,7 +48,7 @@ services:
       - "127.0.0.1:6379:6379"
 
   geth:
-    image: ethereum/client-go:v1.10.23
+    image: ethereum/client-go:v1.13.11
     ports:
       - "127.0.0.1:8545:8545"
       - "127.0.0.1:8551:8551"

--- a/test-node.bash
+++ b/test-node.bash
@@ -311,9 +311,10 @@ if $force_init; then
     echo == Initializing redis
     docker-compose run scripts redis-init --redundancy $redundantsequencers
 
-    echo == Funding l2 funnel
+    echo == Funding l2 funnel and dev key
     docker-compose up -d $INITIAL_SEQ_NODES
     docker-compose run scripts bridge-funds --ethamount 100000 --wait
+    docker-compose run scripts bridge-funds --ethamount 1000 --wait --from "key_0x$devprivkey"
 
     if $tokenbridge; then
         echo == Deploying token bridge
@@ -343,9 +344,10 @@ if $force_init; then
         docker-compose run --entrypoint /usr/local/bin/deploy poster --l1conn ws://sequencer:8548 --l1keystore /home/user/l1keystore --sequencerAddress $l3sequenceraddress --ownerAddress $l3owneraddress --l1DeployAccount $l3owneraddress --l1deployment /config/l3deployment.json --authorizevalidators 10 --wasmrootpath /home/user/target/machines --l1chainid=412346 --l2chainconfig /config/l3_chain_config.json --l2chainname orbit-dev-test --l2chaininfo /config/deployed_l3_chain_info.json
         docker-compose run --entrypoint sh poster -c "jq [.[]] /config/deployed_l3_chain_info.json > /config/l3_chain_info.json"
 
-        echo == Funding l3 funnel
+        echo == Funding l3 funnel and dev key
         docker-compose up -d l3node poster
         docker-compose run scripts bridge-to-l3 --ethamount 50000 --wait
+        docker-compose run scripts bridge-to-l3 --ethamount 500 --wait --from "key_0x$devprivkey"
 
     fi
 fi

--- a/test-node.bash
+++ b/test-node.bash
@@ -295,7 +295,7 @@ if $force_init; then
 
     echo == create l1 traffic
     docker-compose run scripts send-l1 --ethamount 1000 --to user_l1user --wait
-    docker-compose run scripts send-l1 --ethamount 0.0001 --from user_l1user --to user_l1user_b --wait --delay 500 --times 500 > /dev/null &
+    docker-compose run scripts send-l1 --ethamount 0.0001 --from user_l1user --to user_l1user_b --wait --delay 500 --times 1000000 > /dev/null &
 
     echo == Writing l2 chain config
     docker-compose run scripts write-l2-chain-config
@@ -331,7 +331,7 @@ if $force_init; then
 
         echo == create l2 traffic
         docker-compose run scripts send-l2 --ethamount 100 --to user_l2user --wait
-        docker-compose run scripts send-l2 --ethamount 0.0001 --from user_l2user --to user_l2user_b --wait --delay 500 --times 500 > /dev/null &
+        docker-compose run scripts send-l2 --ethamount 0.0001 --from user_l2user --to user_l2user_b --wait --delay 500 --times 1000000 > /dev/null &
 
         echo == Writing l3 chain config
         docker-compose run scripts write-l3-chain-config


### PR DESCRIPTION
this gets rid of errors like 
```
staker-unsafe_1                | ERROR[12-05|15:25:00.926] error acting as staker                   err="error getting latest finalized nonce (and queue is not persistent): failed to get the latest or finalized L1 header: not found"
```

and also keep it up to date