### PR TITLE
perf: remove chrome

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:16-bullseye-slim
 WORKDIR /workspace
 COPY ./package.json ./yarn.lock ./
 RUN yarn

--- a/tokenbridge/Dockerfile
+++ b/tokenbridge/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:16-bullseye-slim
 RUN apt-get update && \
-    apt-get install -y git docker.io python3 chromium build-essential
+    apt-get install -y git docker.io python3 build-essential
 WORKDIR /workspace  
 RUN git clone -b reg-weth-gw https://github.com/OffchainLabs/token-bridge-contracts.git ./
 RUN yarn install

--- a/tokenbridge/Dockerfile
+++ b/tokenbridge/Dockerfile
@@ -2,7 +2,7 @@ FROM node:16-bullseye-slim
 RUN apt-get update && \
     apt-get install -y git docker.io python3 build-essential
 WORKDIR /workspace  
-RUN git clone -b reg-weth-gw https://github.com/OffchainLabs/token-bridge-contracts.git ./
+RUN git clone https://github.com/OffchainLabs/token-bridge-contracts.git ./
 RUN yarn install
 RUN yarn build
 ENTRYPOINT ["yarn"]


### PR DESCRIPTION
Removing chromium from the tokenbridge Dockerfile to reduce image size so that it is less likely to use up all space in token-bridge-ui CI. We might also consider to push a base image to reduce build time in CI. i.e.
```
FROM node:16-bullseye-slim
RUN apt-get update && \
    apt-get install -y git docker.io python3 build-essential
```
