### PR TITLE
Add beacon client URL

### DIFF
--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -158,6 +158,9 @@ function writeConfigs(argv: any) {
             "connection": {
                 "url": argv.l1url,
             },
+            "blob-client": {
+                "beacon-url": "http://prysm_beacon_chain:3500"
+            },
         },
         "chain": {
             "id": 412346,

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -158,9 +158,6 @@ function writeConfigs(argv: any) {
             "connection": {
                 "url": argv.l1url,
             },
-            "blob-client": {
-                "beacon-url": "http://prysm_beacon_chain:3500"
-            },
         },
         "chain": {
             "id": 412346,
@@ -184,7 +181,8 @@ function writeConfigs(argv: any) {
             },
             "sequencer": false,
             "dangerous": {
-                "no-sequencer-coordinator": false
+                "no-sequencer-coordinator": false,
+                "disable-blob-reader": true,
             },
             "delayed-sequencer": {
                 "enable": false


### PR DESCRIPTION
This will be required with https://github.com/OffchainLabs/nitro/pull/2148

Right now we aren't enabling 4844 in the test node so this won't be used in practice, but I hope to change that.

Edit: for now I've just disabled the blob reader, because it won't start up otherwise if prysm is disabled (as is default)