### PR TITLE
fix: wrong l2 chain owner and nonce issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,21 +102,35 @@ For help and further scripts, see:
 
 ## Named accounts
 
+Here is a list of address that are used in the testnode setup, avoid using them before the deployment finishes or you might end up with some nonce race.
+
 ```bash
-./test-node.bash script print-address --account sequencer
+./test-node.bash scripts print-address --account <name>
+./test-node.bash scripts print-private-key --account <name>
 ```
+
 ```
 sequencer:                  0xe2148eE53c0755215Df69b2616E552154EdC584f
 validator:                  0x6A568afe0f82d34759347bb36F14A6bB171d2CBe
 l2owner:                    0x5E1497dD1f08C87b2d8FE23e9AAB6c1De833D927
 l3owner:                    0x863c904166E801527125D8672442D736194A3362
 l3sequencer:                0x3E6134aAD4C4d422FF2A4391Dc315c4DDf98D1a5
-user_l1user:                0x058E6C774025ade66153C65672219191c72c7095
+user_l1traffic:             0xa2db25762CFdF7bAF602F3Bcf2ec534937725f00
+user_l1traffic_b:           0xacC305CaCB4605Aa1975001e24D25F7A5d11dC61
+user_l2traffic:             0x7641C76365faC5090d315410358073D4ba199c57
+user_l2traffic_b:           0x0d25ca3B2c4b8e8c9fe4104Fbd6D37B9563FdaE4
 user_token_bridge_deployer: 0x3EaCb30f025630857aDffac9B2366F953eFE4F98
 user_fee_token_deployer:    0x2AC5278D230f88B481bBE4A94751d7188ef48Ca2
 ```
 
-While not a named account, 0x3f1eae7d46d88f08fc2f8ed27fcb2ab183eb2d0e is funded on all test chains.
+While not a named account, 0x3f1eae7d46d88f08fc2f8ed27fcb2ab183eb2d0e is funded on all test chains and is used to fund other accounts.
+
+The following accounts are funded on L1, L2, and L3 respectively and can be used for testing without risk of nonce race from testnode setup:
+```
+user_l1user:                0x058E6C774025ade66153C65672219191c72c7095
+user_l2user:                0xEEA8EC07A3642769168D40e3Abd05Af5F1c56c44
+user_l3user:                0xE87cF1C248e62c1EdaD39a1e134570D368BdF39A
+```
 
 ## Contact
 

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -377,7 +377,7 @@ function writeL3ChainConfig(argv: any) {
             "AllowDebugPrecompiles": true,
             "DataAvailabilityCommittee": false,
             "InitialArbOSVersion": 11,
-            "InitialChainOwner": "0x0000000000000000000000000000000000000000",
+            "InitialChainOwner": argv.l3owner,
             "GenesisBlockNum": 0
         }
     }

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -28,7 +28,8 @@ async function main() {
       l2url: { string: true, default: "ws://sequencer:8548" },
       l3url: { string: true, default: "ws://l3node:3348" },
       validationNodeUrl: { string: true, default: "ws://validation_node:8549" },
-      l2owner: { string: true, default: "0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E" },
+      l2owner: { string: true, default: "0x0000000000000000000000000000000000000000" },
+      l3owner: { string: true, default: "0x0000000000000000000000000000000000000000" },
     })
     .options(stressOptions)
     .command(bridgeFundsCommand)

--- a/test-node.bash
+++ b/test-node.bash
@@ -333,11 +333,11 @@ if $force_init; then
     docker compose run scripts send-l1 --ethamount 1000 --to user_l1user --wait
     docker compose run scripts send-l1 --ethamount 0.0001 --from user_l1user --to user_l1user_b --wait --delay 500 --times 1000000 > /dev/null &
 
-    echo == Writing l2 chain config
-    docker compose run scripts write-l2-chain-config
-
     sequenceraddress=`docker compose run scripts print-address --account sequencer | tail -n 1 | tr -d '\r\n'`
     l2ownerAddress=`docker compose run scripts print-address --account l2owner | tail -n 1 | tr -d '\r\n'`
+
+    echo == Writing l2 chain config
+    docker compose run scripts write-l2-chain-config --l2owner $l2ownerAddress
 
     docker compose run --entrypoint /usr/local/bin/deploy sequencer --l1conn ws://geth:8546 --l1keystore /home/user/l1keystore --sequencerAddress $sequenceraddress --ownerAddress $l2ownerAddress --l1DeployAccount $l2ownerAddress --l1deployment /config/deployment.json --authorizevalidators 10 --wasmrootpath /home/user/target/machines --l1chainid=$l1chainid --l2chainconfig /config/l2_chain_config.json --l2chainname arb-dev-test --l2chaininfo /config/deployed_chain_info.json
     docker compose run --entrypoint sh sequencer -c "jq [.[]] /config/deployed_chain_info.json > /config/l2_chain_info.json"
@@ -386,8 +386,9 @@ if $force_init; then
         docker compose run scripts send-l2 --ethamount 100 --to user_traffic_generator --wait
         docker compose run scripts send-l2 --ethamount 0.0001 --from user_traffic_generator --to user_fee_token_deployer --wait --delay 500 --times 1000000 > /dev/null &
 
+        l3owneraddress=`docker compose run scripts print-address --account l3owner | tail -n 1 | tr -d '\r\n'`
         echo == Writing l3 chain config
-        docker compose run scripts write-l3-chain-config
+        docker compose run scripts write-l3-chain-config --l3owner $l3owneraddress
 
         if $l3_custom_fee_token; then
             echo == Deploying custom fee token
@@ -396,7 +397,6 @@ if $force_init; then
         fi
 
         echo == Deploying L3
-        l3owneraddress=`docker compose run scripts print-address --account l3owner | tail -n 1 | tr -d '\r\n'`
         l3ownerkey=`docker compose run scripts print-private-key --account l3owner | tail -n 1 | tr -d '\r\n'`
         l3sequenceraddress=`docker compose run scripts print-address --account l3sequencer | tail -n 1 | tr -d '\r\n'`
         docker compose run --entrypoint /usr/local/bin/deploy sequencer --l1conn ws://sequencer:8548 --l1keystore /home/user/l1keystore --sequencerAddress $l3sequenceraddress --ownerAddress $l3owneraddress --l1DeployAccount $l3owneraddress --l1deployment /config/l3deployment.json --authorizevalidators 10 --wasmrootpath /home/user/target/machines --l1chainid=412346 --l2chainconfig /config/l3_chain_config.json --l2chainname orbit-dev-test --l2chaininfo /config/deployed_l3_chain_info.json --maxDataSize 104857 $EXTRA_L3_DEPLOY_FLAG

--- a/test-node.bash
+++ b/test-node.bash
@@ -324,6 +324,9 @@ if $force_init; then
       docker compose up --wait geth
     fi
 
+    echo == Funding l1 user
+    docker compose run scripts send-l1 --ethamount 100 --to user_l1user --wait
+
     echo == Funding validator, sequencer, l2owner and token bridge deployer
     docker compose run scripts send-l1 --ethamount 1000 --to validator --wait
     docker compose run scripts send-l1 --ethamount 1000 --to sequencer --wait
@@ -331,8 +334,8 @@ if $force_init; then
     docker compose run scripts send-l1 --ethamount 1000 --to user_token_bridge_deployer --wait
 
     echo == create l1 traffic
-    docker compose run scripts send-l1 --ethamount 1000 --to user_l1user --wait
-    docker compose run scripts send-l1 --ethamount 0.0001 --from user_l1user --to user_l1user_b --wait --delay 500 --times 1000000 > /dev/null &
+    docker compose run scripts send-l1 --ethamount 1000 --to user_l1traffic --wait
+    docker compose run scripts send-l1 --ethamount 0.0001 --from user_l1traffic --to user_l1traffic_b --wait --delay 500 --times 1000000 > /dev/null &
 
     sequenceraddress=`docker compose run scripts print-address --account sequencer | tail -n 1 | tr -d '\r\n'`
     l2ownerAddress=`docker compose run scripts print-address --account l2owner | tail -n 1 | tr -d '\r\n'`
@@ -360,6 +363,9 @@ if $force_init; then
     docker compose run scripts bridge-funds --ethamount 100000 --wait
     docker compose run scripts bridge-funds --ethamount 1000 --wait --from "key_0x$devprivkey"
 
+    echo == Funding l2 user
+    docker compose run scripts send-l2 --ethamount 100 --to user_l2user --wait
+
     if $tokenbridge; then
         echo == Deploying L1-L2 token bridge
         sleep 10 # no idea why this sleep is needed but without it the deploy fails randomly
@@ -372,7 +378,7 @@ if $force_init; then
     fi
 
     if $l3node; then
-        echo == Funding l3 users
+        echo == Funding l3 owner and sequencer
         docker compose run scripts send-l2 --ethamount 1000 --to l3owner --wait
         docker compose run scripts send-l2 --ethamount 1000 --to l3sequencer --wait
 
@@ -384,8 +390,8 @@ if $force_init; then
         docker compose run scripts send-l2 --ethamount 100 --to user_fee_token_deployer --wait
 
         echo == create l2 traffic
-        docker compose run scripts send-l2 --ethamount 100 --to user_traffic_generator --wait
-        docker compose run scripts send-l2 --ethamount 0.0001 --from user_traffic_generator --to user_fee_token_deployer --wait --delay 500 --times 1000000 > /dev/null &
+        docker compose run scripts send-l2 --ethamount 100 --to user_l2traffic --wait
+        docker compose run scripts send-l2 --ethamount 0.0001 --from user_l2traffic --to user_l2traffic_b --wait --delay 500 --times 1000000 > /dev/null &
 
         l3owneraddress=`docker compose run scripts print-address --account l3owner | tail -n 1 | tr -d '\r\n'`
         echo == Writing l3 chain config
@@ -431,6 +437,8 @@ if $force_init; then
             docker compose run scripts bridge-to-l3 --ethamount 500 --wait --from "key_0x$devprivkey"
         fi
 
+        echo == Funding l3 user
+        docker compose run scripts send-l3 --ethamount 100 --to user_l3user --wait
     fi
 fi
 


### PR DESCRIPTION
fixes an issue where the incorrect chain owner is set in the chain config file, leading to unexpected l2 chain owner
the new l2owner private key can be obtained by
```bash
docker compose run scripts print-private-key --account l2owner | tail -n 1 | tr -d '\r\n'
```

also moving to use the token bridge deployer for l1l2 bridge to reduce chance of nonce race

also added l1user, l2user and l3user as nonce race free accounts