### PR TITLE
temporarily remove `disable-blob-config`

### DIFF
--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -182,7 +182,7 @@ function writeConfigs(argv: any) {
             "sequencer": false,
             "dangerous": {
                 "no-sequencer-coordinator": false,
-                "disable-blob-reader": true,
+                // "disable-blob-reader": true, todo: reactivate when nitro version is bumped
             },
             "delayed-sequencer": {
                 "enable": false


### PR DESCRIPTION
This config option is preventing the sequencer from booting up.

This causes the `arbitrum-sdk` tests to fail, and anyone using `master` cannot boot up nitro.