### PR TITLE
Set default contracts versions

### DIFF
--- a/.github/workflows/testnode.bash
+++ b/.github/workflows/testnode.bash
@@ -6,7 +6,7 @@
 cd ${GITHUB_WORKSPACE}
 
 # TODO once develop is merged into nitro-contract's master, remove the NITRO_CONTRACTS_BRANCH env var
-NITRO_CONTRACTS_BRANCH=develop ./test-node.bash --init-force --detach
+./test-node.bash --init-force --detach
 
 START=$(date +%s)
 SUCCEDED=0

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -331,7 +331,7 @@ services:
     build:
       context: tokenbridge/
       args:
-        TOKEN_BRIDGE_BRANCH: ${TOKEN_BRIDGE_BRANCH:-main}
+        TOKEN_BRIDGE_BRANCH: ${TOKEN_BRIDGE_BRANCH:-}
     environment:
       - ARB_URL=http://sequencer:8547
       - ETH_URL=http://geth:8545
@@ -347,7 +347,7 @@ services:
     build:
       context: rollupcreator/
       args:
-        NITRO_CONTRACTS_BRANCH: ${NITRO_CONTRACTS_BRANCH:-main}
+        NITRO_CONTRACTS_BRANCH: ${NITRO_CONTRACTS_BRANCH:-}
     volumes:
       - "config:/config"
       - /var/run/docker.sock:/var/run/docker.sock

--- a/test-node.bash
+++ b/test-node.bash
@@ -5,6 +5,20 @@ set -e
 NITRO_NODE_VERSION=offchainlabs/nitro-node:v2.3.3-6a1c1a7-dev
 BLOCKSCOUT_VERSION=offchainlabs/blockscout:v1.0.0-c8db5b1
 
+# This commit matches the v1.2.1 contracts, with additional fixes for rollup deployment script.
+# Once v1.2.2 is released, we can switch to that version.
+DEFAULT_NITRO_CONTRACTS_VERSION="2e8eeb9f28104465de0557851aa7607b037cafcf"
+DEFAULT_TOKEN_BRIDGE_VERSION="v1.2.1"
+
+# Set default versions if not overriden by provided env vars
+: ${NITRO_CONTRACTS_BRANCH:=$DEFAULT_NITRO_CONTRACTS_VERSION}
+: ${TOKEN_BRIDGE_BRANCH:=$DEFAULT_TOKEN_BRIDGE_VERSION}
+export NITRO_CONTRACTS_BRANCH
+export TOKEN_BRIDGE_BRANCH
+
+echo "Using NITRO_CONTRACTS_BRANCH: $NITRO_CONTRACTS_BRANCH"
+echo "Using TOKEN_BRIDGE_BRANCH: $TOKEN_BRIDGE_BRANCH"
+
 mydir=`dirname $0`
 cd "$mydir"
 


### PR DESCRIPTION
Sets the default nitro-contracts and token-bridge versions in the `test-node.bash`.  It's the only place where default versions are set. Default versions can be overriden if `NITRO_CONTRACTS_BRANCH` and `TOKEN_BRIDGE_BRANCH` env vars are provided.