### PR TITLE
Skipping --rm flag instead of --no-rm (deprecated)

### DIFF
--- a/test-node.bash
+++ b/test-node.bash
@@ -278,7 +278,7 @@ if $force_build; then
   if $tokenbridge || $l3_token_bridge; then
     LOCAL_BUILD_NODES="$LOCAL_BUILD_NODES tokenbridge"
   fi
-  docker compose build --no-rm $LOCAL_BUILD_NODES
+  docker compose build $LOCAL_BUILD_NODES
 fi
 
 if $dev_build_nitro; then
@@ -300,7 +300,7 @@ else
 fi
 
 if $force_build; then
-    docker compose build --no-rm $NODES scripts
+    docker compose build $NODES scripts
 fi
 
 if $force_init; then


### PR DESCRIPTION
Issue: Running ./test-node.bash will result in error:

`unknown flag: --no-rm`

Did some tweaking and found that if we just skip providing --rm flag, it will be as good as --no-rm which seems to be deprecated

I was able to remove these flags and run things successfully