### PR TITLE
Remove deprecated version property

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   blockscout:
     depends_on:


### PR DESCRIPTION
Got warning when running test node
```
WARN[0000] /Users/estensen/Developer/nitro/nitro-testnode/docker-compose.yaml: `version` is obsolete
```

https://docs.docker.com/compose/compose-file/04-version-and-name/