### PR TITLE
Deploy CacheManager to L2 and L3

### DIFF
--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -378,7 +378,7 @@ function writeL3ChainConfig(argv: any) {
             "AllowDebugPrecompiles": true,
             "DataAvailabilityCommittee": false,
             "InitialArbOSVersion": 30,
-            "InitialChainOwner": "0x0000000000000000000000000000000000000000",
+            "InitialChainOwner": argv.l2owner,
             "GenesisBlockNum": 0
         }
     }

--- a/test-node.bash
+++ b/test-node.bash
@@ -461,7 +461,6 @@ if $force_init; then
         fi
         docker compose run scripts send-l3 --ethamount 100 --to l3owner --wait
 
-
         echo == Deploy CacheManager on L3
         docker compose run -e CHILD_CHAIN_RPC="http://l3node:3347" -e CHAIN_OWNER_PRIVKEY=$l3ownerkey rollupcreator deploy-cachemanager-testnode
 

--- a/test-node.bash
+++ b/test-node.bash
@@ -5,9 +5,9 @@ set -e
 NITRO_NODE_VERSION=offchainlabs/nitro-node:v3.0.1-cf4b74e-dev
 BLOCKSCOUT_VERSION=offchainlabs/blockscout:v1.0.0-c8db5b1
 
-# This commit matches the v1.2.1 contracts, with additional fixes for rollup deployment script.
+# This commit matches the v1.2.1 contracts, with additional support for CacheManger deployment.
 # Once v1.2.2 is released, we can switch to that version.
-DEFAULT_NITRO_CONTRACTS_VERSION="a00d2faac01e050339ff7b0ac5bc91df06e8dbff"
+DEFAULT_NITRO_CONTRACTS_VERSION="867663657b98a66b60ff244e46226e0cb368ab94"
 DEFAULT_TOKEN_BRIDGE_VERSION="v1.2.1"
 
 # Set default versions if not overriden by provided env vars


### PR DESCRIPTION
Deploy CacheManager and enable it on L2 and L3 by calling nitro-contracts' action
Set initial chain owners on L2 and L3 to be l2owner and l3owner accounts

Resolves BLK-170