### PR TITLE
feat: use node v18

### DIFF
--- a/rollupcreator/Dockerfile
+++ b/rollupcreator/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-bullseye-slim
+FROM node:18-bullseye-slim
 ARG NITRO_CONTRACTS_BRANCH=main
 RUN apt-get update && \
     apt-get install -y git docker.io python3 build-essential curl jq

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-bullseye-slim
+FROM node:18-bullseye-slim
 WORKDIR /workspace
 COPY ./package.json ./yarn.lock ./
 RUN yarn

--- a/tokenbridge/Dockerfile
+++ b/tokenbridge/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-bullseye-slim
+FROM node:18-bullseye-slim
 ARG TOKEN_BRIDGE_BRANCH=main
 RUN apt-get update && \
     apt-get install -y git docker.io python3 build-essential


### PR DESCRIPTION
Node.js 16 reached end of life on September 11, 2023, we are deprecating v16 support in nitro-contracts and other repo. This PR bump nodejs to v18 in the container base images.