### PR TITLE
Clarify logic around dev builds and rebuilding

### DIFF
--- a/test-node.bash
+++ b/test-node.bash
@@ -69,6 +69,8 @@ while [[ $# -gt 0 ]]; do
                 read -p "are you sure? [y/n]" -n 1 response
                 if [[ $response == "y" ]] || [[ $response == "Y" ]]; then
                     force_init=true
+                    build_contracts=true
+                    build_node_images=true
                     echo
                 else
                     exit 0
@@ -78,6 +80,8 @@ while [[ $# -gt 0 ]]; do
             ;;
         --init-force)
             force_init=true
+            build_contracts=true
+            build_node_images=true
             shift
             ;;
         --dev)

--- a/test-node.bash
+++ b/test-node.bash
@@ -461,6 +461,7 @@ if $force_init; then
         echo l3owneraddress $l3owneraddress
         docker compose run scripts --l2owner $l3owneraddress  write-l3-chain-config
 
+        EXTRA_L3_DEPLOY_FLAG=""
         if $l3_custom_fee_token; then
             echo == Deploying custom fee token
             nativeTokenAddress=`docker compose run scripts create-erc20 --deployer user_fee_token_deployer --mintTo user_token_bridge_deployer --bridgeable $tokenbridge | tail -n 1 | awk '{ print $NF }'`

--- a/test-node.bash
+++ b/test-node.bash
@@ -37,7 +37,6 @@ else
 fi
 
 run=true
-skip_build=false
 validate=false
 detach=false
 blockscout=false


### PR DESCRIPTION
    The concepts of using the dev builds for nitro and blockscout and
    rebuilding are now split into different variables internally to the
    test-node.bash script and can be controlled independently.
    
    The --dev flag by itself means to use the dev builds and to rebuild
    them. --no-build-dev-nitro and -no-build-dev-blockscout disable
    rebuilding the respective dev images. --no-build disables rebuilding the
    dev images and also rebuilding contracts related images, and the node
    images. This finer grained control saves time in the development cycle
    by allowing the user to rebuild only what is needed.
    
    An example command line to reinitialize the blockchain, use the dev
    images, but not rebuild anything except blockscout would be:
    ./test-node.bash --init --dev --no-build --build-dev-blockscout --blockscout
    
    Flags are read from left to right; flags to the right cancel
    the effects of flags to the left.
