### PR TITLE
Fix docker layers caching in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile') }}
+          key: ${{ runner.os }}-buildx-${{ hashFiles('**/Dockerfile') }}
           restore-keys: ${{ runner.os }}-buildx-
 
       - name: Startup Nitro testnode

--- a/.github/workflows/testnode.bash
+++ b/.github/workflows/testnode.bash
@@ -5,7 +5,7 @@
 # Start the test node and get PID, to terminate it once send-l2 is done.
 cd ${GITHUB_WORKSPACE}
 
-./test-node.bash "$@"
+./test-node.bash "$@" --ci
 
 if [ $? -ne 0 ]; then
     echo "test-node.bash failed"

--- a/docker-compose-ci-cache.json
+++ b/docker-compose-ci-cache.json
@@ -1,0 +1,37 @@
+{
+  "target": {
+    "scripts": {
+      "cache-from": [
+        "type=local,src=/tmp/.buildx-cache"
+      ],
+      "cache-to": [
+        "type=local,dest=/tmp/.buildx-cache,mode=max"
+      ],
+      "output": [
+        "type=docker"
+      ]
+    },
+    "rollupcreator": {
+      "cache-from": [
+        "type=local,src=/tmp/.buildx-cache"
+      ],
+      "cache-to": [
+        "type=local,dest=/tmp/.buildx-cache,mode=max"
+      ],
+      "output": [
+        "type=docker"
+      ]
+    },
+    "tokenbridge": {
+      "cache-from": [
+        "type=local,src=/tmp/.buildx-cache"
+      ],
+      "cache-to": [
+        "type=local,dest=/tmp/.buildx-cache,mode=max"
+      ],
+      "output": [
+        "type=docker"
+      ]
+    }
+  }
+}

--- a/test-node.bash
+++ b/test-node.bash
@@ -366,7 +366,7 @@ if $blockscout; then
 fi
 
 if $build_node_images; then
-    docker compose build --no-rm $NODES scripts
+    docker compose build --no-rm $NODES
 fi
 
 if $force_init; then


### PR DESCRIPTION
Resolves NIT-2643

Fix docker layers caching in CI.

It doesn't improve CI running time by much though, something around 20% better. 

You can check it working by re-running the CI workflows of this PR, or creating a new PR that doesn't modify Dockerfiles based on the branch of this PR, and check cache being hit.