### PR TITLE
Add --l2-anytrust option to run in AnyTrust mode

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -388,7 +388,7 @@ services:
       - "config:/config"
       - "das-committee-a-data:/das"
     command:
-      - --conf.file=/config/l2_das_committee_a.json
+      - --conf.file=/config/l2_das_committee.json
 
   das-committee-b:
     pid: host # allow debugging
@@ -401,7 +401,7 @@ services:
       - "config:/config"
       - "das-committee-b-data:/das"
     command:
-      - --conf.file=/config/l2_das_committee_b.json
+      - --conf.file=/config/l2_das_committee.json
 
   das-mirror:
     pid: host # allow debugging

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -361,6 +361,54 @@ services:
       - "config:/config"
       - /var/run/docker.sock:/var/run/docker.sock
 
+  datool:
+    image: nitro-node-dev-testnode
+    entrypoint: /usr/local/bin/datool
+    volumes:
+      - "config:/config"
+      - "das-committee-a-data:/das-committee-a"
+      - "das-committee-b-data:/das-committee-b"
+      - "das-mirror-data:/das-mirror"
+    command:
+
+  das-committee-a:
+    pid: host # allow debugging
+    image: nitro-node-dev-testnode
+    entrypoint: /usr/local/bin/daserver
+    ports:
+      - "127.0.0.1:9876:9876"
+      - "127.0.0.1:9877:9877"
+    volumes:
+      - "config:/config"
+      - "das-committee-a-data:/das"
+    command:
+      - --conf.file=/config/l2_das_committee_a.json
+
+  das-committee-b:
+    pid: host # allow debugging
+    image: nitro-node-dev-testnode
+    entrypoint: /usr/local/bin/daserver
+    ports:
+      - "127.0.0.1:8876:9876"
+      - "127.0.0.1:8877:9877"
+    volumes:
+      - "config:/config"
+      - "das-committee-b-data:/das"
+    command:
+      - --conf.file=/config/l2_das_committee_b.json
+
+  das-mirror:
+    pid: host # allow debugging
+    image: nitro-node-dev-testnode
+    entrypoint: /usr/local/bin/daserver
+    ports:
+      - "127.0.0.1:7877:9877"
+    volumes:
+      - "config:/config"
+      - "das-mirror-data:/das"
+    command:
+      - --conf.file=/config/l2_das_mirror.json
+
 volumes:
   l1data:
   consensus:
@@ -377,3 +425,6 @@ volumes:
   config:
   postgres-data:
   tokenbridge-data:
+  das-committee-a-data:
+  das-committee-b-data:
+  das-mirror-data:

--- a/scripts/ethcommands.ts
+++ b/scripts/ethcommands.ts
@@ -279,6 +279,25 @@ export const createERC20Command = {
   },
 };
 
+// Will revert if the keyset is already valid.
+async function setValidKeyset(argv: any, upgradeExecutorAddr: string, sequencerInboxAddr: string, keyset: string){
+    const innerIface = new ethers.utils.Interface(["function setValidKeyset(bytes)"])
+    const innerData = innerIface.encodeFunctionData("setValidKeyset", [keyset]);
+
+    // The Executor contract is the owner of the SequencerInbox so calls must be made
+    // through it.
+    const outerIface = new ethers.utils.Interface(["function executeCall(address,bytes)"])
+    argv.data = outerIface.encodeFunctionData("executeCall", [sequencerInboxAddr, innerData]);
+
+    argv.from = "l2owner";
+    argv.to = "address_" + upgradeExecutorAddr
+    argv.ethamount = "0"
+
+    await runStress(argv, sendTransaction);
+
+    argv.provider.destroy();
+}
+
 export const transferERC20Command = {
   command: "transfer-erc20",
   describe: "transfers ERC20 token",
@@ -429,5 +448,26 @@ export const sendRPCCommand = {
         const rpcProvider = new ethers.providers.JsonRpcProvider(argv.url)
 
         await rpcProvider.send(argv.method, argv.params)
+    }
+}
+
+export const setValidKeysetCommand = {
+    command: "set-valid-keyset",
+    describe: "sets the anytrust keyset",
+    handler: async (argv: any) => {
+        argv.provider = new ethers.providers.WebSocketProvider(argv.l1url);
+        const deploydata = JSON.parse(
+            fs
+                .readFileSync(path.join(consts.configpath, "deployment.json"))
+                .toString()
+        );
+        const sequencerInboxAddr = ethers.utils.hexlify(deploydata["sequencer-inbox"]);
+        const upgradeExecutorAddr = ethers.utils.hexlify(deploydata["upgrade-executor"]);
+
+        const keyset = fs
+            .readFileSync(path.join(consts.configpath, "l2_das_keyset.hex"))
+            .toString()
+
+        await setValidKeyset(argv, upgradeExecutorAddr, sequencerInboxAddr, keyset)
     }
 }

--- a/scripts/ethcommands.ts
+++ b/scripts/ethcommands.ts
@@ -386,7 +386,7 @@ async function setValidKeyset(argv: any, upgradeExecutorAddr: string, sequencerI
     argv.to = "address_" + upgradeExecutorAddr
     argv.ethamount = "0"
 
-    await runStress(argv, sendTransaction);
+    await sendTransaction(argv, 0);
 
     argv.provider.destroy();
 }

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -2,7 +2,7 @@ import { hideBin } from "yargs/helpers";
 import Yargs from "yargs/yargs";
 import { stressOptions } from "./stress";
 import { redisReadCommand, redisInitCommand } from "./redis";
-import { writeConfigCommand, writeGethGenesisCommand, writePrysmCommand, writeL2ChainConfigCommand, writeL3ChainConfigCommand } from "./config";
+import { writeConfigCommand, writeGethGenesisCommand, writePrysmCommand, writeL2ChainConfigCommand, writeL3ChainConfigCommand, writeL2DASCommitteeConfigCommand, writeL2DASMirrorConfigCommand, writeL2DASKeysetConfigCommand } from "./config";
 import {
   printAddressCommand,
   namedAccountHelpString,
@@ -19,6 +19,7 @@ import {
   sendL2Command,
   sendL3Command,
   sendRPCCommand,
+  setValidKeysetCommand,
 } from "./ethcommands";
 
 async function main() {
@@ -30,6 +31,7 @@ async function main() {
       l3url: { string: true, default: "ws://l3node:3348" },
       validationNodeUrl: { string: true, default: "ws://validation_node:8549" },
       l2owner: { string: true, default: "0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E" },
+      committeeMember: { string: true, default: "not_set" },
     })
     .options(stressOptions)
     .command(bridgeFundsCommand)
@@ -41,10 +43,14 @@ async function main() {
     .command(sendL2Command)
     .command(sendL3Command)
     .command(sendRPCCommand)
+    .command(setValidKeysetCommand)
     .command(writeConfigCommand)
     .command(writeGethGenesisCommand)
     .command(writeL2ChainConfigCommand)
     .command(writeL3ChainConfigCommand)
+    .command(writeL2DASCommitteeConfigCommand)
+    .command(writeL2DASMirrorConfigCommand)
+    .command(writeL2DASKeysetConfigCommand)
     .command(writePrysmCommand)
     .command(writeAccountsCommand)
     .command(printAddressCommand)

--- a/test-node.bash
+++ b/test-node.bash
@@ -50,6 +50,7 @@ batchposters=1
 devprivkey=b6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659
 l1chainid=1337
 simple=true
+l2anytrust=false
 
 # Use the dev versions of nitro/blockscout
 dev_nitro=false
@@ -209,6 +210,10 @@ while [[ $# -gt 0 ]]; do
             l3_token_bridge=true
             shift
             ;;
+        --l2-anytrust)
+			l2anytrust=true
+			shift
+			;;
         --redundantsequencers)
             simple=false
             redundantsequencers=$2
@@ -241,6 +246,7 @@ while [[ $# -gt 0 ]]; do
             echo --l3node          deploys an L3 node on top of the L2
             echo --l3-fee-token    L3 chain is set up to use custom fee token. Only valid if also '--l3node' is provided
             echo --l3-token-bridge Deploy L2-L3 token bridge. Only valid if also '--l3node' is provided
+			echo --l2-anytrust     run the L2 as an AnyTrust chain
             echo --batchposters    batch posters [0-3]
             echo --redundantsequencers redundant sequencers [0-3]
             echo --detach          detach from nodes after running them
@@ -265,6 +271,13 @@ done
 
 NODES="sequencer"
 INITIAL_SEQ_NODES="sequencer"
+
+#if $l2anytrust; then
+#	#	NODES="$NODES das-committee-a das-committee-b das-mirror"
+#    NODES="$NODES das-committee-a das-committee-b"
+#fi
+
+#NODES="$NODES sequencer"
 
 if ! $simple; then
     NODES="$NODES redis"
@@ -302,7 +315,6 @@ fi
 if $blockscout; then
     NODES="$NODES blockscout"
 fi
-
 
 if $dev_nitro && $build_dev_nitro; then
   echo == Building Nitro
@@ -408,8 +420,13 @@ if $force_init; then
 
     l2ownerAddress=`docker compose run scripts print-address --account l2owner | tail -n 1 | tr -d '\r\n'`
 
-    echo == Writing l2 chain config
-    docker compose run scripts --l2owner $l2ownerAddress  write-l2-chain-config
+    if $l2anytrust; then
+        echo "== Writing l2 chain config (anytrust enabled)"
+        docker compose run scripts --l2owner $l2ownerAddress  write-l2-chain-config --anytrust
+    else
+        echo == Writing l2 chain config
+        docker compose run scripts --l2owner $l2ownerAddress  write-l2-chain-config
+    fi
 
     sequenceraddress=`docker compose run scripts print-address --account sequencer | tail -n 1 | tr -d '\r\n'`
     l2ownerKey=`docker compose run scripts print-private-key --account l2owner | tail -n 1 | tr -d '\r\n'`
@@ -419,12 +436,48 @@ if $force_init; then
     docker compose run -e PARENT_CHAIN_RPC="http://geth:8545" -e DEPLOYER_PRIVKEY=$l2ownerKey -e PARENT_CHAIN_ID=$l1chainid -e CHILD_CHAIN_NAME="arb-dev-test" -e MAX_DATA_SIZE=117964 -e OWNER_ADDRESS=$l2ownerAddress -e WASM_MODULE_ROOT=$wasmroot -e SEQUENCER_ADDRESS=$sequenceraddress -e AUTHORIZE_VALIDATORS=10 -e CHILD_CHAIN_CONFIG_PATH="/config/l2_chain_config.json" -e CHAIN_DEPLOYMENT_INFO="/config/deployment.json" -e CHILD_CHAIN_INFO="/config/deployed_chain_info.json" rollupcreator create-rollup-testnode
     docker compose run --entrypoint sh rollupcreator -c "jq [.[]] /config/deployed_chain_info.json > /config/l2_chain_info.json"
 
+fi # $force_init
+
+anytrustNodeConfigLine=""
+
+# Remaining init may require AnyTrust committee/mirrors to have been started
+if $l2anytrust; then
+    if $force_init; then
+        echo == Generating AnyTrust Config
+        docker compose run --user root --entrypoint sh datool -c "mkdir /das-committee-a/keys /das-committee-a/data /das-committee-a/metadata /das-committee-b/keys /das-committee-b/data /das-committee-b/metadata /das-mirror/data /das-mirror/metadata"
+        docker compose run --user root --entrypoint sh datool -c "chown -R 1000:1000 /das*"
+        docker compose run datool keygen --dir /das-committee-a/keys
+        docker compose run datool keygen --dir /das-committee-b/keys
+		sequencerinbox=`docker compose run --entrypoint sh datool -c "cat /config/l2_chain_info.json | jq -r '.[].rollup.\"sequencer-inbox\"'"`
+        docker compose run scripts write-l2-das-committee-config --committeeMember a
+	    docker compose run scripts write-l2-das-committee-config --committeeMember b
+        docker compose run scripts write-l2-das-mirror-config
+    fi
+
+    das_bls_a=`docker compose run --entrypoint sh datool -c "cat /das-committee-a/keys/das_bls.pub"`
+    das_bls_b=`docker compose run --entrypoint sh datool -c "cat /das-committee-b/keys/das_bls.pub"`
+
+    docker compose run scripts write-l2-das-keyset-config --dasBlsA $das_bls_a --dasBlsB $das_bls_b
+    docker compose run --entrypoint sh datool -c "/usr/local/bin/datool dumpkeyset --conf.file /config/l2_das_keyset.json | grep 'Keyset: ' | awk '{ printf \"%s\", \$2 }' > /config/l2_das_keyset.hex"
+    docker compose run scripts set-valid-keyset
+
+    anytrustNodeConfigLine="--anytrust --dasBlsA $das_bls_a --dasBlsB $das_bls_b"
+
+	if $run; then
+		echo == Starting AnyTrust committee and mirror
+		docker compose up --wait das-committee-a das-committee-b das-mirror
+        # TODO how to make these containers go down since they are now
+        # run in the background
+	fi
+fi
+
+if $force_init; then
     if $simple; then
         echo == Writing configs
-        docker compose run scripts write-config --simple
+        docker compose run scripts write-config --simple $anytrustNodeConfigLine
     else
         echo == Writing configs
-        docker compose run scripts write-config
+        docker compose run scripts write-config $anytrustNodeConfigLine
 
         echo == Initializing redis
         docker compose up --wait redis


### PR DESCRIPTION
test-node.bash can now be run with --l2-anytrust which runs the l2 nodes in AnyTrust mode. It creates a committee of 2 daserver with assumed-honest set to 1, requiring successful stores of the batch data to both of them. Nitro nodes sync from a mirror daserver. All dasevers use local file storage for the batch data on their own volumes.

BLS keys for the committee are automatically generated and the keyset is activated automatically on the SequencerInbox contract.

# Testing done
Tested that --no-run generates config correctly:
```
./test-node.bash --init-force --dev --l2-anytrust --no-build --no-run
...
# inspecting various config files
 docker compose run --entrypoint sh scripts -c "cat /config/l2_das_keyset.json"  |jq .
```

Tested running
```
./test-node.bash --init-force --dev --l2-anytrust --no-build

...
# keyset is set
{                                                                                                                                                                                                     
  type: 2,                                                                                                                                                                                            
  chainId: 1337,                                                                                                                                                                                      
  nonce: 27,                                                                                                                                                                                          
  maxPriorityFeePerGas: BigNumber { _hex: '0x59682f00', _isBigNumber: true },                                                                                                                         
  maxFeePerGas: BigNumber { _hex: '0x59683026', _isBigNumber: true },                                                                                                                                 
  gasPrice: null,                                                                                                                                                                                     
  gasLimit: BigNumber { _hex: '0x020d2e', _isBigNumber: true },                                                                                                                                       
  to: '0x513D9F96d4D0563DEbae8a0DC307ea0E46b10ed7',                                                                                                                                                   
  value: BigNumber { _hex: '0x00', _isBigNumber: true },                                                                                                                                              
  data: '0xbca8c7b500000000000000000000000018d19c5d3e685f5be5b9c86e097f0e439285d2160000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000
00000000002a4d1ce8da800000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000256000000000000000100000000000000020121600e2afd75d94
45e25d89c11d2bc2b3e5238030df8c173e40365a8f0f0f1c133d82488d31b073f692fd6e57085d315f5f0031b49e83a69a00ca8d9660cb752322848042ba7496be7a62909dea1a44a9f7f0525444651f42f824c6ee0283a91c8d51435843fdbd1010b0
8d8d93da421c93129f849bbc2a0922faa25771892801a7de61e7b6d79863b45ba2b1e4c26cc2a03142864d8e1ad15630ac086eee52c76d532a7c154560b07206131e56ee62c6a0bba34ecb2af058b85ab54fd39ae3500870d22b2a6e8c16eaba02c258
54335a842db48674a35a34ad7c0201e18c5a82baa2c1675d40daa508d04d8f41860aa8e280f879a03dec5292fd0602e3bd22d80b1aca3d55c76c16f0ddc0e2af11f1a208e91d1c8d768fefb46076f1f2444307b5e01216010e0d4a5f89ea133f412905
44ae4c7a9c2de2f9a18862ce81ea631673129a5a3effe1223d8b89a5228f30716cf2d14dd05cb725034ea4ce871521720493f5182c6e6fe6546f1ab5cc18efd15ad5c2596dfc2d24116980b081ac8313b4061e18d0d6d0df4c545bb8c57786f048cca1
f817ca0b35c1c23fd017361d8748c3ea08fae77e77d3c566e7934687a4e216dd6bd01e2bac8c0a3bba51155998d9bccbdc189d2f39c84f8b61422cfdd6bd49d750eb111ad47b69f68924c777e2082e822e517ce962b4f0edd60c065d4d4fec3bc3a9d3
525b99085132dc2090b74322a696e4adb4cff34e722d6a378b0b726935581148d0be648707341647d10c2b003ae9fa4f091286135c3f36b1ee619f7412abd70879a6eea733c896fefe5894ff0d9b700000000000000000000000000000000000000000
00000000000000000000000000000000000',                                                                                                                                                                 
  accessList: [],                                                                                                                                                                                     
  hash: '0xfaf59ee50c29e9212d5f2a6d39a027d5f2bdaa60ccb41aa2b6a8baf314b4124f',                                                                                                                         
  v: 1,                                                                                            
  r: '0xef5ad4feaae965b80ee0c3612c291b776e400c0028befac8f0a5e721983ec9b2',                                                                                                                            
  s: '0x7759530029617e1ade9875e8deb5a1283d9e266056cafd3325711093f6fbc527',                                                                                                                            
  from: '0x5E1497dD1f08C87b2d8FE23e9AAB6c1De833D927',                                                                                                                                                 
  confirmations: 0,                              
  wait: [Function (anonymous)]                                                                                                                                                                        
}                                        
...
== Starting AnyTrust committee and mirror                                                                                                                                   
[+] Running 3/3                                  
 ✔ Container nitro-testnode-das-committee-a-1  He...                                              0.8s                                                                                                
 ✔ Container nitro-testnode-das-committee-b-1  He...                                              0.8s                                                                                                
 ✔ Container nitro-testnode-das-mirror-1       Healthy                                            0.8s      
...
```

Check the das mirror has some data, meaning the batch poster successfully posted the data and it was synced by the mirror from the committee.
```
$ docker compose run --entrypoint sh das-mirror -c "ls -lR /das/data/"
WARN[0000] Found orphan containers ([nitro-testnode-scripts-run-a35e3922ff7e nitro-testnode-das-mirror-run-fee25f4f176d]) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up. 
/das/data/:
total 0
drwx------. 1 user user  4 Sep  4 17:00 by-data-hash
drwx------. 1 user user 12 Sep  4 17:00 by-expiry-timestamp

/das/data/by-data-hash:
total 0
drwx------. 1 user user 4 Sep  4 17:00 5b

/das/data/by-data-hash/5b:
total 0
drwx------. 1 user user 128 Sep  4 17:00 85

/das/data/by-data-hash/5b/85:
total 4
-rw-------. 2 user user 3831 Sep  4 17:00 5b859f91e827b270666856439a18ee9f3df31f2240d5a599adba707438577ba1

/das/data/by-expiry-timestamp:
total 0
drwx------. 1 user user 8 Sep  4 17:00 172676

/das/data/by-expiry-timestamp/172676:
total 0
drwx------. 1 user user 128 Sep  4 17:00 5254

/das/data/by-expiry-timestamp/172676/5254:
total 4
-rw-------. 2 user user 3831 Sep  4 17:00 5b859f91e827b270666856439a18ee9f3df31f2240d5a599adba707438577ba1
```