### PR TITLE
Timeboost mode for nitro-testnode

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -168,7 +168,7 @@ services:
       - "l1keystore:/home/user/l1keystore"
       - "config:/config"
       - "tokenbridge-data:/tokenbridge-data"
-    command: --conf.file /config/sequencer_config.json --node.feed.output.enable --node.feed.output.port 9642  --http.api net,web3,eth,txpool,debug --node.seq-coordinator.my-url  ws://sequencer:8548 --graphql.enable --graphql.vhosts * --graphql.corsdomain * --execution.sequencer.timeboost.sequencer-http-endpoint http://sequencer:8547 --auth.addr 0.0.0.0 --auth.api auctioneer,eth,validation --auth.jwtsecret=/config/jwt.hex --auth.origins *
+    command: --conf.file /config/sequencer_config.json --node.feed.output.enable --node.feed.output.port 9642  --http.api net,web3,eth,txpool,debug --node.seq-coordinator.my-url  ws://sequencer:8548 --graphql.enable --graphql.vhosts * --graphql.corsdomain * --auth.addr 0.0.0.0 --auth.api auctioneer,eth,validation --auth.jwtsecret=/config/jwt.hex --auth.origins *
     depends_on:
       - geth
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -422,8 +422,9 @@ services:
     volumes:
       - "config:/config"
       - "timeboost-auctioneer-data:/data"
+      - "l1keystore:/home/user/l1keystore"
     command:
-      - --auctioneer-server.redis-url redis://redis:6379
+      - --conf.file=/config/autonomous_auctioneer_config.json
     depends_on:
       - redis
 
@@ -431,6 +432,10 @@ services:
     pid: host # allow debugging
     image: nitro-node-dev-testnode
     entrypoint: /usr/local/bin/autonomous-auctioneer
+    volumes:
+      - "config:/config"
+    command:
+      - --conf.file=/config/bid_validator_config.json
     depends_on:
       - redis
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -161,7 +161,6 @@ services:
     ports:
       - "127.0.0.1:8547:8547"
       - "127.0.0.1:8548:8548"
-      - "127.0.0.1:9549:8549"
       - "127.0.0.1:9642:9642"
     volumes:
       - "seqdata:/home/user/.arbitrum/local/nitro"
@@ -172,15 +171,11 @@ services:
       - --conf.file=/config/sequencer_config.json
       - --node.feed.output.enable
       - --node.feed.output.port=9642
-      - --http.api=net,web3,eth,txpool,debug,timeboost
-      - --node.seq-coordinator.my-url=ws://sequencer:8548
+      - --http.api=net,web3,eth,txpool,debug,timeboost,auctioneer
+      - --node.seq-coordinator.my-url=http://sequencer:8547
       - --graphql.enable
       - --graphql.vhosts=*
       - --graphql.corsdomain=*
-      - --auth.addr=0.0.0.0
-      - --auth.api=auctioneer,eth,validation
-      - --auth.jwtsecret=/config/jwt.hex
-      - --auth.origins=*
     depends_on:
       - geth
 
@@ -194,7 +189,10 @@ services:
     volumes:
       - "seqdata_b:/home/user/.arbitrum/local/nitro"
       - "config:/config"
-    command: --conf.file /config/sequencer_config.json --node.seq-coordinator.my-url ws://sequencer_b:8548
+    command:
+      - --conf.file=/config/sequencer_config.json
+      - --node.seq-coordinator.my-url=http://sequencer_b:8547
+      - --http.api=net,web3,eth,txpool,debug,timeboost,auctioneer
     depends_on:
       - geth
       - redis
@@ -209,7 +207,10 @@ services:
     volumes:
       - "seqdata_c:/home/user/.arbitrum/local/nitro"
       - "config:/config"
-    command: --conf.file /config/sequencer_config.json --node.seq-coordinator.my-url ws://sequencer_c:8548
+    command:
+      - --conf.file=/config/sequencer_config.json
+      - --node.seq-coordinator.my-url=http://sequencer_c:8547
+      - --http.api=net,web3,eth,txpool,debug,timeboost,auctioneer
     depends_on:
       - geth
       - redis
@@ -224,7 +225,10 @@ services:
     volumes:
       - "seqdata_d:/home/user/.arbitrum/local/nitro"
       - "config:/config"
-    command: --conf.file /config/sequencer_config.json --node.seq-coordinator.my-url ws://sequencer_d:8548
+    command:
+      - --conf.file=/config/sequencer_config.json
+      - --node.seq-coordinator.my-url=http://sequencer_d:8547
+      - --http.api=net,web3,eth,txpool,debug,timeboost,auctioneer
     depends_on:
       - geth
       - redis

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -415,6 +415,25 @@ services:
     command:
       - --conf.file=/config/l2_das_mirror.json
 
+  timeboost-auctioneer:
+    pid: host # allow debugging
+    image: nitro-node-dev-testnode
+    entrypoint: /usr/local/bin/autonomous-auctioneer
+    volumes:
+      - "config:/config"
+      - "timeboost-auctioneer-data:/data"
+   command:
+      - --auctioneer-server.redis-url redis://redis:6379
+    depends_on:
+      - redis
+
+  timeboost-bid-validator:
+    pid: host # allow debugging
+    image: nitro-node-dev-testnode
+    entrypoint: /usr/local/bin/autonomous-auctioneer
+    depends_on:
+      - redis
+
 volumes:
   l1data:
   consensus:
@@ -434,3 +453,4 @@ volumes:
   das-committee-a-data:
   das-committee-b-data:
   das-mirror-data:
+  timeboost-auctioneer-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -168,7 +168,19 @@ services:
       - "l1keystore:/home/user/l1keystore"
       - "config:/config"
       - "tokenbridge-data:/tokenbridge-data"
-    command: --conf.file /config/sequencer_config.json --node.feed.output.enable --node.feed.output.port 9642  --http.api net,web3,eth,txpool,debug --node.seq-coordinator.my-url  ws://sequencer:8548 --graphql.enable --graphql.vhosts * --graphql.corsdomain * --auth.addr 0.0.0.0 --auth.api auctioneer,eth,validation --auth.jwtsecret=/config/jwt.hex --auth.origins *
+    command:
+      - --conf.file=/config/sequencer_config.json
+      - --node.feed.output.enable
+      - --node.feed.output.port=9642
+      - --http.api=net,web3,eth,txpool,debug,timeboost
+      - --node.seq-coordinator.my-url=ws://sequencer:8548
+      - --graphql.enable
+      - --graphql.vhosts=*
+      - --graphql.corsdomain=*
+      - --auth.addr=0.0.0.0
+      - --auth.api=auctioneer,eth,validation
+      - --auth.jwtsecret=/config/jwt.hex
+      - --auth.origins=*
     depends_on:
       - geth
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -167,7 +167,7 @@ services:
       - "l1keystore:/home/user/l1keystore"
       - "config:/config"
       - "tokenbridge-data:/tokenbridge-data"
-    command: --conf.file /config/sequencer_config.json --node.feed.output.enable --node.feed.output.port 9642  --http.api net,web3,eth,txpool,debug --node.seq-coordinator.my-url  ws://sequencer:8548 --graphql.enable --graphql.vhosts * --graphql.corsdomain *
+    command: --conf.file /config/sequencer_config.json --node.feed.output.enable --node.feed.output.port 9642  --http.api net,web3,eth,txpool,debug --node.seq-coordinator.my-url  ws://sequencer:8548 --graphql.enable --graphql.vhosts * --graphql.corsdomain * --execution.sequencer.timeboost.sequencer-http-endpoint http://sequencer:8547
     depends_on:
       - geth
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -161,13 +161,14 @@ services:
     ports:
       - "127.0.0.1:8547:8547"
       - "127.0.0.1:8548:8548"
+      - "127.0.0.1:9549:8549"
       - "127.0.0.1:9642:9642"
     volumes:
       - "seqdata:/home/user/.arbitrum/local/nitro"
       - "l1keystore:/home/user/l1keystore"
       - "config:/config"
       - "tokenbridge-data:/tokenbridge-data"
-    command: --conf.file /config/sequencer_config.json --node.feed.output.enable --node.feed.output.port 9642  --http.api net,web3,eth,txpool,debug --node.seq-coordinator.my-url  ws://sequencer:8548 --graphql.enable --graphql.vhosts * --graphql.corsdomain * --execution.sequencer.timeboost.sequencer-http-endpoint http://sequencer:8547
+    command: --conf.file /config/sequencer_config.json --node.feed.output.enable --node.feed.output.port 9642  --http.api net,web3,eth,txpool,debug --node.seq-coordinator.my-url  ws://sequencer:8548 --graphql.enable --graphql.vhosts * --graphql.corsdomain * --execution.sequencer.timeboost.sequencer-http-endpoint http://sequencer:8547 --auth.addr 0.0.0.0 --auth.api auctioneer,eth,validation --auth.jwtsecret=/config/jwt.hex --auth.origins *
     depends_on:
       - geth
 
@@ -432,10 +433,16 @@ services:
     pid: host # allow debugging
     image: nitro-node-dev-testnode
     entrypoint: /usr/local/bin/autonomous-auctioneer
+    ports:
+      - "127.0.0.1:9372:8547"
     volumes:
       - "config:/config"
     command:
       - --conf.file=/config/bid_validator_config.json
+      - --http.addr=0.0.0.0
+      - --http.corsdomain=*
+      - --http.api=auctioneer
+      - --log-level=INFO
     depends_on:
       - redis
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -452,6 +452,7 @@ services:
     command:
       - --conf.file=/config/bid_validator_config.json
       - --http.addr=0.0.0.0
+      - --http.vhosts=*
       - --http.corsdomain=*
       - --http.api=auctioneer
       - --log-level=INFO

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -422,7 +422,7 @@ services:
     volumes:
       - "config:/config"
       - "timeboost-auctioneer-data:/data"
-   command:
+    command:
       - --auctioneer-server.redis-url redis://redis:6379
     depends_on:
       - redis

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -98,7 +98,6 @@ services:
       - --output-ssz=/consensus/genesis.ssz
       - --chain-config-file=/config/prysm.yaml
       - --geth-genesis-json-in=/config/geth_genesis.json
-      - --geth-genesis-json-out=/config/geth_genesis.json
     volumes:
       - "consensus:/consensus"
       - "config:/config"

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -9,7 +9,7 @@ FROM base AS pre-build
 COPY ./*.ts ./tsconfig.json ./
 COPY ./nitro-contracts ./nitro-contracts
 
-RUN if [ -d "./nitro-contracts/DEV_CONTRACTS" ]; then \
+RUN if [ -f "./nitro-contracts/DEV_CONTRACTS" ]; then \
       echo "Overwriting @arbitrum/nitro-contracts with local version"; \
       rm -rf node_modules/@arbitrum/nitro-contracts; \
       cp -a ./nitro-contracts node_modules/@arbitrum/nitro-contracts; \

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -9,7 +9,7 @@ FROM base AS pre-build
 COPY ./*.ts ./tsconfig.json ./
 COPY ./nitro-contracts ./nitro-contracts
 
-RUN if [ -d "./nitro-contracts" ]; then \
+RUN if [ -d "./nitro-contracts/DEV_CONTRACTS" ]; then \
       echo "Overwriting @arbitrum/nitro-contracts with local version"; \
       rm -rf node_modules/@arbitrum/nitro-contracts; \
       cp -a ./nitro-contracts node_modules/@arbitrum/nitro-contracts; \

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -7,16 +7,6 @@ RUN yarn
 # Stage 2: Copy files and run build
 FROM base AS pre-build
 COPY ./*.ts ./tsconfig.json ./
-COPY ./nitro-contracts ./nitro-contracts
-
-RUN if [ -f "./nitro-contracts/DEV_CONTRACTS" ]; then \
-      echo "Overwriting @arbitrum/nitro-contracts with local version"; \
-      rm -rf node_modules/@arbitrum/nitro-contracts; \
-      cp -a ./nitro-contracts node_modules/@arbitrum/nitro-contracts; \
-    else \
-      echo "local nitro-contracts directory not found, using npm version"; \
-    fi
-# At this stage, the intermediate image will stop
 RUN echo "Intermediate image created before yarn build"
 
 # Stage 3: Final build

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,7 +1,25 @@
-FROM node:18-bullseye-slim
+# Stage 1: Base build environment
+FROM node:18-bullseye-slim AS base
 WORKDIR /workspace
 COPY ./package.json ./yarn.lock ./
 RUN yarn
+
+# Stage 2: Copy files and run build
+FROM base AS pre-build
 COPY ./*.ts ./tsconfig.json ./
+COPY ./nitro-contracts ./nitro-contracts
+
+RUN if [ -d "./nitro-contracts" ]; then \
+      echo "Overwriting @arbitrum/nitro-contracts with local version"; \
+      rm -rf node_modules/@arbitrum/nitro-contracts; \
+      cp -a ./nitro-contracts node_modules/@arbitrum/nitro-contracts; \
+    else \
+      echo "local nitro-contracts directory not found, using npm version"; \
+    fi
+# At this stage, the intermediate image will stop
+RUN echo "Intermediate image created before yarn build"
+
+# Stage 3: Final build
+FROM pre-build AS final
 RUN yarn build
 ENTRYPOINT ["node", "index.js"]

--- a/scripts/accounts.ts
+++ b/scripts/accounts.ts
@@ -5,7 +5,7 @@ import * as crypto from "crypto";
 import { runStress } from "./stress";
 const path = require("path");
 
-const specialAccounts = 6;
+const specialAccounts = 7;
 
 async function writeAccounts() {
   for (let i = 0; i < specialAccounts; i++) {
@@ -47,6 +47,9 @@ export function namedAccount(
   if (name == "l2owner") {
     return specialAccount(5);
   }
+  if (name == "auctioneer") {
+    return specialAccount(6);
+  }
   if (name.startsWith("user_")) {
     return new ethers.Wallet(
       ethers.utils.sha256(ethers.utils.toUtf8Bytes(name))
@@ -85,7 +88,8 @@ export function namedAddress(
 
 export const namedAccountHelpString =
   "Valid account names:\n" +
-  "  funnel | sequencer | validator | l2owner - known keys used by l2\n" +
+  "  funnel | sequencer | validator | l2owner\n" +
+  "    | auctioneer                           - known keys used by l2\n" +
   "  l3owner | l3sequencer                    - known keys used by l3\n" +
   "  user_[Alphanumeric]                      - key will be generated from username\n" +
   "  threaduser_[Alphanumeric]                - same as user_[Alphanumeric]_thread_[thread-id]\n" +

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -319,7 +319,8 @@ function writeConfigs(argv: any) {
           // Initially we create it disabled but then replace it using test-node.bash
           // once we have the contract and auctioneer address.
           sequencerConfig.execution.sequencer.timeboost = {
-             "enable": false
+             "enable": false,
+             "redis-url": argv.redisUrl
           };
         }
         fs.writeFileSync(path.join(consts.configpath, "sequencer_config.json"), JSON.stringify(sequencerConfig))
@@ -550,8 +551,8 @@ function writeAutonomousAuctioneerConfig(argv: any) {
       "auction-contract-address": argv.auctionContract,
       "db-directory": "/data",
       "redis-url": "redis://redis:6379",
-      "sequencer-endpoint": "http://sequencer:8547",
-      "sequencer-jwt-path": "/config/jwt.hex",
+      "use-redis-coordinator": true,
+      "redis-coordinator-url": "redis://redis:6379",
       "wallet":  {
         "account": namedAddress("auctioneer"),
         "password": consts.l1passphrase,

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -311,7 +311,8 @@ function writeConfigs(argv: any) {
         sequencerConfig.execution["sequencer"].enable = true
         sequencerConfig.node["delayed-sequencer"].enable = true
         if (argv.timeboost) {
-          sequencerConfig.execution.sequencer.timeboost = {
+          sequencerConfig.execution.sequencer.dangerous = {};
+          sequencerConfig.execution.sequencer.dangerous.timeboost = {
              "enable": true,
              "redis-url": argv.redisUrl
           };

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -514,6 +514,42 @@ function dasBackendsJsonConfig(argv: any) {
     return backends
 }
 
+function writeAutonomousAuctioneerConfig(argv: any) {
+    const autonomousAuctioneerConfig = {
+        "auctioneer-server": {
+            "auction-contract-address": "TODO",
+            "db-directory": "/data",
+            "redis-url": "redis://redis:6379",
+            "sequencer-endpoint": "http://sequencer:8547",
+            "sequencer-jwt-path": "/config/jwt.hex",
+            "wallet":  {
+                "account": namedAddress("auctioneer"),
+                "password": consts.l1passphrase,
+                "pathname": consts.l1keystore
+            },
+        },
+        "bid-validator": {
+            "enable": false
+        }
+    }
+    const autonomousAuctioneerConfigJSON = JSON.stringify(autonomousAuctioneerConfig)
+    fs.writeFileSync(path.join(consts.configpath, "autonomous_auctioneer_config.json"), autonomousAuctioneerConfigJSON)
+}
+
+function writeBidValidatorConfig(argv: any) {
+    const bidValidatorConfig = {
+        "auctioneer-server": {
+            "enable": false
+        }
+        "bid-validator": {
+            "auction-contract-address": "TODO",
+            "redis-url": "redis://redis:6379"
+        }
+    }
+    const bidValidatorConfigJSON = JSON.stringify(bidValidatorConfig)
+    fs.writeFileSync(path.join(consts.configpath, bid_validator_config.json"), bidValidatorConfigJSON)
+}
+
 export const writeConfigCommand = {
     command: "write-config",
     describe: "writes config files",
@@ -619,4 +655,12 @@ export const writeL2DASKeysetConfigCommand = {
     handler: (argv: any) => {
        writeL2DASKeysetConfig(argv)
     }
+}
+
+function auctioneerServerConfig(argv: any) {
+    const conf = {
+        "auctioneer-server": {
+        }
+    }
+    return conf
 }

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -204,9 +204,6 @@ function writeConfigs(argv: any) {
                 "strategy": "MakeNodes",
             },
             "sequencer": false,
-            "transaction-streamer": {
-                "track-block-metadata-from": 0
-            },
             "dangerous": {
                 "no-sequencer-coordinator": false,
                 "disable-blob-reader": true,
@@ -288,7 +285,6 @@ function writeConfigs(argv: any) {
         simpleConfig.node.staker["use-smart-contract-wallet"] = true
         simpleConfig.node.staker.dangerous["without-block-validator"] = true
         simpleConfig.node.sequencer = true
-        simpleConfig.node["transaction-streamer"]["track-block-metadata-from"] = 1
         simpleConfig.node.dangerous["no-sequencer-coordinator"] = true
         simpleConfig.node["delayed-sequencer"].enable = true
         simpleConfig.node["batch-poster"].enable = true
@@ -311,15 +307,12 @@ function writeConfigs(argv: any) {
 
         let sequencerConfig = JSON.parse(baseConfJSON)
         sequencerConfig.node.sequencer = true
-        sequencerConfig.node["transaction-streamer"]["track-block-metadata-from"] = 1
         sequencerConfig.node["seq-coordinator"].enable = true
         sequencerConfig.execution["sequencer"].enable = true
         sequencerConfig.node["delayed-sequencer"].enable = true
         if (argv.timeboost) {
-          // Initially we create it disabled but then replace it using test-node.bash
-          // once we have the contract and auctioneer address.
           sequencerConfig.execution.sequencer.timeboost = {
-             "enable": false,
+             "enable": true,
              "redis-url": argv.redisUrl
           };
         }
@@ -344,7 +337,6 @@ function writeConfigs(argv: any) {
     l3Config.node.staker.enable = true
     l3Config.node.staker["use-smart-contract-wallet"] = true
     l3Config.node.sequencer = true
-    l3Config.node["transaction-streamer"]["track-block-metadata-from"] = 1
     l3Config.execution["sequencer"].enable = true
     l3Config.node["dangerous"]["no-sequencer-coordinator"] = true
     l3Config.node["delayed-sequencer"].enable = true

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -540,14 +540,14 @@ function writeBidValidatorConfig(argv: any) {
     const bidValidatorConfig = {
         "auctioneer-server": {
             "enable": false
-        }
+        },
         "bid-validator": {
             "auction-contract-address": "TODO",
             "redis-url": "redis://redis:6379"
         }
     }
     const bidValidatorConfigJSON = JSON.stringify(bidValidatorConfig)
-    fs.writeFileSync(path.join(consts.configpath, bid_validator_config.json"), bidValidatorConfigJSON)
+    fs.writeFileSync(path.join(consts.configpath, "bid_validator_config.json"), bidValidatorConfigJSON)
 }
 
 export const writeConfigCommand = {

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -310,9 +310,11 @@ function writeConfigs(argv: any) {
         sequencerConfig.execution["sequencer"].enable = true
         sequencerConfig.node["delayed-sequencer"].enable = true
         if (argv.timeboost) {
-           sequencerConfig.execution.sequencer.timeboost = {
-              "enable": true
-           };
+          // Initially we create it disabled but then replace it using test-node.bash
+          // once we have the contract and auctioneer address.
+          sequencerConfig.execution.sequencer.timeboost = {
+             "enable": false
+          };
         }
         fs.writeFileSync(path.join(consts.configpath, "sequencer_config.json"), JSON.stringify(sequencerConfig))
 

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -550,7 +550,7 @@ function writeAutonomousAuctioneerConfig(argv: any) {
       "auction-contract-address": argv.auctionContract,
       "db-directory": "/data",
       "redis-url": "redis://redis:6379",
-      "sequencer-endpoint": "ws://sequencer:8549",
+      "sequencer-endpoint": "http://sequencer:8547",
       "sequencer-jwt-path": "/config/jwt.hex",
       "wallet":  {
         "account": namedAddress("auctioneer"),

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -388,7 +388,7 @@ function writeL2ChainConfig(argv: any) {
             "EnableArbOS": true,
             "AllowDebugPrecompiles": true,
             "DataAvailabilityCommittee": argv.anytrust,
-            "InitialArbOSVersion": 31, // TODO put back to version 32
+            "InitialArbOSVersion": 32, // TODO For Timeboost, this still needs to be set to 31
             "InitialChainOwner": argv.l2owner,
             "GenesisBlockNum": 0
         }

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -539,7 +539,7 @@ function writeAutonomousAuctioneerConfig(argv: any) {
       "auction-contract-address": argv.auctionContract,
       "db-directory": "/data",
       "redis-url": "redis://redis:6379",
-      "sequencer-endpoint": "http://sequencer:8547",
+      "sequencer-endpoint": "ws://sequencer:8549",
       "sequencer-jwt-path": "/config/jwt.hex",
       "wallet":  {
         "account": namedAddress("auctioneer"),

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -258,6 +258,9 @@ function writeConfigs(argv: any) {
         "execution": {
             "sequencer": {
                 "enable": false,
+                "timeboost": {
+                  "enable": false
+                }
             },
             "forwarding-target": "null",
         },

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -257,10 +257,7 @@ function writeConfigs(argv: any) {
         },
         "execution": {
             "sequencer": {
-                "enable": false,
-                "timeboost": {
-                  "enable": false
-                }
+                "enable": false
             },
             "forwarding-target": "null",
         },
@@ -312,6 +309,11 @@ function writeConfigs(argv: any) {
         sequencerConfig.node["seq-coordinator"].enable = true
         sequencerConfig.execution["sequencer"].enable = true
         sequencerConfig.node["delayed-sequencer"].enable = true
+        if (argv.timeboost) {
+           sequencerConfig.execution.sequencer.timeboost = {
+              "enable": true
+           };
+        }
         fs.writeFileSync(path.join(consts.configpath, "sequencer_config.json"), JSON.stringify(sequencerConfig))
 
         let posterConfig = JSON.parse(baseConfJSON)
@@ -594,7 +596,11 @@ export const writeConfigCommand = {
             describe: "DAS committee member B BLS pub key",
             default: ""
         },
-
+        timeboost: {
+            boolean: true,
+            describe: "run sequencer in timeboost mode",
+            default: false
+        },
       },
     handler: (argv: any) => {
         writeConfigs(argv)

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -385,7 +385,7 @@ function writeL2ChainConfig(argv: any) {
             "EnableArbOS": true,
             "AllowDebugPrecompiles": true,
             "DataAvailabilityCommittee": argv.anytrust,
-            "InitialArbOSVersion": 32,
+            "InitialArbOSVersion": 31, // TODO put back to version 32
             "InitialChainOwner": argv.l2owner,
             "GenesisBlockNum": 0
         }
@@ -514,40 +514,57 @@ function dasBackendsJsonConfig(argv: any) {
     return backends
 }
 
+export const writeTimeboostConfigsCommand = {
+  command: "write-timeboost-configs",
+  describe: "writes configs for the timeboost autonomous auctioneer and bid validator",
+  builder: {
+    "auction-contract": {
+      string: true,
+      describe: "auction contract address",
+      demandOption: true
+    },
+  },
+  handler: (argv: any) => {
+    writeAutonomousAuctioneerConfig(argv)
+    writeBidValidatorConfig(argv)
+  }
+}
+
 function writeAutonomousAuctioneerConfig(argv: any) {
-    const autonomousAuctioneerConfig = {
-        "auctioneer-server": {
-            "auction-contract-address": "TODO",
-            "db-directory": "/data",
-            "redis-url": "redis://redis:6379",
-            "sequencer-endpoint": "http://sequencer:8547",
-            "sequencer-jwt-path": "/config/jwt.hex",
-            "wallet":  {
-                "account": namedAddress("auctioneer"),
-                "password": consts.l1passphrase,
-                "pathname": consts.l1keystore
-            },
-        },
-        "bid-validator": {
-            "enable": false
-        }
+  const autonomousAuctioneerConfig = {
+    "auctioneer-server": {
+      "auction-contract-address": argv.auctionContract,
+      "db-directory": "/data",
+      "redis-url": "redis://redis:6379",
+      "sequencer-endpoint": "http://sequencer:8547",
+      "sequencer-jwt-path": "/config/jwt.hex",
+      "wallet":  {
+        "account": namedAddress("auctioneer"),
+        "password": consts.l1passphrase,
+        "pathname": consts.l1keystore
+      },
+    },
+    "bid-validator": {
+      "enable": false
     }
-    const autonomousAuctioneerConfigJSON = JSON.stringify(autonomousAuctioneerConfig)
-    fs.writeFileSync(path.join(consts.configpath, "autonomous_auctioneer_config.json"), autonomousAuctioneerConfigJSON)
+  }
+  const autonomousAuctioneerConfigJSON = JSON.stringify(autonomousAuctioneerConfig)
+  fs.writeFileSync(path.join(consts.configpath, "autonomous_auctioneer_config.json"), autonomousAuctioneerConfigJSON)
 }
 
 function writeBidValidatorConfig(argv: any) {
-    const bidValidatorConfig = {
-        "auctioneer-server": {
-            "enable": false
-        },
-        "bid-validator": {
-            "auction-contract-address": "TODO",
-            "redis-url": "redis://redis:6379"
-        }
+  const bidValidatorConfig = {
+    "auctioneer-server": {
+      "enable": false
+    },
+    "bid-validator": {
+      "auction-contract-address": argv.auctionContract,
+      "redis-url": "redis://redis:6379",
+      "sequencer-endpoint": "http://sequencer:8547"
     }
-    const bidValidatorConfigJSON = JSON.stringify(bidValidatorConfig)
-    fs.writeFileSync(path.join(consts.configpath, "bid_validator_config.json"), bidValidatorConfigJSON)
+  }
+  const bidValidatorConfigJSON = JSON.stringify(bidValidatorConfig)
+  fs.writeFileSync(path.join(consts.configpath, "bid_validator_config.json"), bidValidatorConfigJSON)
 }
 
 export const writeConfigCommand = {

--- a/scripts/ethcommands.ts
+++ b/scripts/ethcommands.ts
@@ -407,7 +407,7 @@ export const deployExpressLaneAuctionContractCommand = {
     console.log("ExpressLaneAuction contract deployed at address:", contract.address);
 
     const auctioneerAddr = namedAddress(argv.auctioneer)
-    const initIface = new ethers.utils.Interface(["function initialize((address,address,address,(uint64,uint64,uint64,uint64),uint256,address,address,address,address,address,address,address))"])
+    const initIface = new ethers.utils.Interface(["function initialize((address,address,address,(int64,uint64,uint64,uint64),uint256,address,address,address,address,address,address,address))"])
     const initData = initIface.encodeFunctionData("initialize", [[
       auctioneerAddr, //_auctioneer
       argv.biddingToken, //_biddingToken

--- a/scripts/ethcommands.ts
+++ b/scripts/ethcommands.ts
@@ -416,7 +416,7 @@ export const deployExpressLaneAuctionContractCommand = {
         Math.round(Date.now() / 60000) * 60,  // offsetTimestamp - most recent minute
         60, // roundDurationSeconds
         15, // auctionClosingSeconds
-        45  // reserveSubmissionSeconds
+        15  // reserveSubmissionSeconds
       ],// RoundTiminginfo
       1, // _minReservePrice
       auctioneerAddr, //_auctioneerAdmin

--- a/scripts/ethcommands.ts
+++ b/scripts/ethcommands.ts
@@ -344,15 +344,6 @@ export const createERC20Command = {
           .toString()
       );
 
-      const l1provider = new ethers.providers.WebSocketProvider(argv.l1url);
-      const l2provider = new ethers.providers.WebSocketProvider(argv.l2url);
-
-      const deployerWallet = namedAccount(argv.deployer).connect(l1provider)
-
-      const tokenAddress = await deployERC20Contract(deployerWallet, argv.decimals);
-      const token = new ethers.Contract(tokenAddress, ERC20.abi, deployerWallet);
-      console.log("Contract deployed at L1 address:", token.address);
-
       const l1GatewayRouter = new ethers.Contract(l1l2tokenbridge.l2Network.tokenBridge.l1GatewayRouter, L1GatewayRouter.abi, deployerWallet);
       await (await token.functions.approve(l1l2tokenbridge.l2Network.tokenBridge.l1ERC20Gateway, ethers.constants.MaxUint256)).wait();
       const supply = await token.totalSupply();

--- a/scripts/ethcommands.ts
+++ b/scripts/ethcommands.ts
@@ -7,9 +7,16 @@ import * as L1AtomicTokenBridgeCreator from "@arbitrum/token-bridge-contracts/bu
 import * as ERC20 from "@openzeppelin/contracts/build/contracts/ERC20.json";
 import * as fs from "fs";
 import { ARB_OWNER } from "./consts";
-import * as ExpressLaneAuctionContract from "@arbitrum/nitro-contracts/out/ExpressLaneAuction.sol/ExpressLaneAuction.json"
 import * as TransparentUpgradeableProxy from "@openzeppelin/contracts/build/contracts/TransparentUpgradeableProxy.json"
 const path = require("path");
+
+let ExpressLaneAuctionContract: any;
+try {
+  ExpressLaneAuctionContract = require("@arbitrum/nitro-contracts/out/ExpressLaneAuction.sol/ExpressLaneAuction.json");
+} catch (e) {
+  console.warn("ExpressLaneAuction contract JSON not found. This is expected if not running with --l2timeboost.");
+}
+
 
 async function sendTransaction(argv: any, threadId: number) {
     const account = namedAccount(argv.from, threadId).connect(argv.provider)
@@ -385,6 +392,11 @@ export const deployExpressLaneAuctionContractCommand = {
     }
   },
   handler: async (argv: any) => {
+    if (!ExpressLaneAuctionContract) {
+      console.error("ExpressLaneAuctionContract is not available. Ensure that you are using the correct contracts branch.");
+      process.exit(1);
+    }
+
     console.log("deploy ExpressLaneAuction contract");
     argv.provider = new ethers.providers.WebSocketProvider(argv.l2url);
     const l2OwnerWallet = namedAccount("l2owner").connect(argv.provider)

--- a/scripts/ethcommands.ts
+++ b/scripts/ethcommands.ts
@@ -8,15 +8,8 @@ import * as ERC20 from "@openzeppelin/contracts/build/contracts/ERC20.json";
 import * as fs from "fs";
 import { ARB_OWNER } from "./consts";
 import * as TransparentUpgradeableProxy from "@openzeppelin/contracts/build/contracts/TransparentUpgradeableProxy.json"
+import * as ExpressLaneAuctionContract from "@arbitrum/nitro-contracts/build/contracts/src/express-lane-auction/ExpressLaneAuction.sol/ExpressLaneAuction.json"
 const path = require("path");
-
-let ExpressLaneAuctionContract: any;
-try {
-  ExpressLaneAuctionContract = require("@arbitrum/nitro-contracts/out/ExpressLaneAuction.sol/ExpressLaneAuction.json");
-} catch (e) {
-  console.warn("ExpressLaneAuction contract JSON not found. This is expected if not running with --l2timeboost.");
-}
-
 
 async function sendTransaction(argv: any, threadId: number) {
     const account = namedAccount(argv.from, threadId).connect(argv.provider)
@@ -392,11 +385,6 @@ export const deployExpressLaneAuctionContractCommand = {
     }
   },
   handler: async (argv: any) => {
-    if (!ExpressLaneAuctionContract) {
-      console.error("ExpressLaneAuctionContract is not available. Ensure that you are using the correct contracts branch.");
-      process.exit(1);
-    }
-
     console.log("deploy ExpressLaneAuction contract");
     argv.provider = new ethers.providers.WebSocketProvider(argv.l2url);
     const l2OwnerWallet = namedAccount("l2owner").connect(argv.provider)

--- a/scripts/ethcommands.ts
+++ b/scripts/ethcommands.ts
@@ -387,8 +387,8 @@ export const deployExpressLaneAuctionContractCommand = {
   handler: async (argv: any) => {
     console.log("deploy ExpressLaneAuction contract");
     argv.provider = new ethers.providers.WebSocketProvider(argv.l2url);
-    const auctioneerWallet = namedAccount(argv.auctioneer).connect(argv.provider)
-    const contractFactory = new ContractFactory(ExpressLaneAuctionContract.abi, ExpressLaneAuctionContract.bytecode, auctioneerWallet)
+    const l2OwnerWallet = namedAccount("l2owner").connect(argv.provider)
+    const contractFactory = new ContractFactory(ExpressLaneAuctionContract.abi, ExpressLaneAuctionContract.bytecode, l2OwnerWallet)
 
     const contract = await contractFactory.deploy();
     await contract.deployTransaction.wait();
@@ -416,8 +416,8 @@ export const deployExpressLaneAuctionContractCommand = {
       auctioneerAddr //_masterAdmin
     ]]);
 
-    const proxyFactory = new ethers.ContractFactory(TransparentUpgradeableProxy.abi, TransparentUpgradeableProxy.bytecode, auctioneerWallet)
-    const proxy = await proxyFactory.deploy(contract.address, namedAddress(argv.auctioneer), initData)
+    const proxyFactory = new ethers.ContractFactory(TransparentUpgradeableProxy.abi, TransparentUpgradeableProxy.bytecode, l2OwnerWallet)
+    const proxy = await proxyFactory.deploy(contract.address, namedAddress("l2owner"), initData)
     await proxy.deployed()
     console.log("Proxy(ExpressLaneAuction) contract deployed at address:", proxy.address);
 

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -2,7 +2,17 @@ import { hideBin } from "yargs/helpers";
 import Yargs from "yargs/yargs";
 import { stressOptions } from "./stress";
 import { redisReadCommand, redisInitCommand } from "./redis";
-import { writeConfigCommand, writeGethGenesisCommand, writePrysmCommand, writeL2ChainConfigCommand, writeL3ChainConfigCommand, writeL2DASCommitteeConfigCommand, writeL2DASMirrorConfigCommand, writeL2DASKeysetConfigCommand } from "./config";
+import {
+  writeConfigCommand,
+  writeGethGenesisCommand,
+  writePrysmCommand,
+  writeL2ChainConfigCommand,
+  writeL3ChainConfigCommand,
+  writeL2DASCommitteeConfigCommand,
+  writeL2DASMirrorConfigCommand,
+  writeL2DASKeysetConfigCommand,
+  writeTimeboostConfigsCommand
+} from "./config";
 import {
   printAddressCommand,
   namedAccountHelpString,
@@ -58,6 +68,7 @@ async function main() {
     .command(writeL2DASKeysetConfigCommand)
     .command(writePrysmCommand)
     .command(writeAccountsCommand)
+    .command(writeTimeboostConfigsCommand)
     .command(printAddressCommand)
     .command(printPrivateKeyCommand)
     .command(redisReadCommand)

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -14,6 +14,7 @@ import {
   bridgeNativeTokenToL3Command,
   bridgeToL3Command,
   createERC20Command,
+  deployExpressLaneAuctionContractCommand,
   transferERC20Command,
   sendL1Command,
   sendL2Command,
@@ -40,6 +41,7 @@ async function main() {
     .command(bridgeToL3Command)
     .command(bridgeNativeTokenToL3Command)
     .command(createERC20Command)
+    .command(deployExpressLaneAuctionContractCommand)
     .command(transferERC20Command)
     .command(sendL1Command)
     .command(sendL2Command)

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -6,7 +6,7 @@
   "author": "Offchain Labs, Inc.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@arbitrum/nitro-contracts": "^2.1.0",
+    "@arbitrum/nitro-contracts": "^2.1.1",
     "@arbitrum/token-bridge-contracts": "1.2.0",
     "@node-redis/client": "^1.0.4",
     "@openzeppelin/contracts": "^4.9.3",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -6,6 +6,7 @@
   "author": "Offchain Labs, Inc.",
   "license": "Apache-2.0",
   "dependencies": {
+    "@arbitrum/nitro-contracts": "^2.1.0",
     "@arbitrum/token-bridge-contracts": "1.2.0",
     "@node-redis/client": "^1.0.4",
     "@openzeppelin/contracts": "^4.9.3",

--- a/scripts/redis.ts
+++ b/scripts/redis.ts
@@ -40,14 +40,14 @@ async function writeRedisPriorities(redisUrl: string, priorities: number) {
   let prio_sequencers = "bcd";
   let priostring = "";
   if (priorities == 0) {
-    priostring = "ws://sequencer:8548";
+    priostring = "http://sequencer:8547";
   }
   if (priorities > prio_sequencers.length) {
     priorities = prio_sequencers.length;
   }
   for (let index = 0; index < priorities; index++) {
     const this_prio =
-      "ws://sequencer_" + prio_sequencers.charAt(index) + ":8548";
+      "http://sequencer_" + prio_sequencers.charAt(index) + ":8547";
     if (index != 0) {
       priostring = priostring + ",";
     }

--- a/test-node.bash
+++ b/test-node.bash
@@ -483,6 +483,7 @@ if $force_init; then
 fi # $force_init
 
 anytrustNodeConfigLine=""
+timeboostNodeConfigLine=""
 
 # Remaining init may require AnyTrust committee/mirrors to have been started
 if $l2anytrust; then
@@ -512,12 +513,15 @@ if $l2anytrust; then
 fi
 
 if $force_init; then
+    if $l2timeboost; then
+        timeboostNodeConfigLine="--timeboost"
+    fi
     if $simple; then
         echo == Writing configs
-        docker compose run scripts write-config --simple $anytrustNodeConfigLine
+        docker compose run scripts write-config --simple $anytrustNodeConfigLine $timeboostNodeConfigLine
     else
         echo == Writing configs
-        docker compose run scripts write-config $anytrustNodeConfigLine
+        docker compose run scripts write-config $anytrustNodeConfigLine $timeboostNodeConfigLine
 
         echo == Initializing redis
         docker compose up --wait redis

--- a/test-node.bash
+++ b/test-node.bash
@@ -360,14 +360,13 @@ if $dev_blockscout && $build_dev_blockscout; then
 fi
 
 # Use dev contracts when building scripts. See scripts/Dockerfile
+rm -rf scripts/nitro-contracts
 if ($build_utils || $build_node_images) && $dev_contracts; then
-  rm -rf scripts/nitro-contracts
   cp -ar ../contracts scripts/nitro-contracts
   touch scripts/nitro-contracts/DEV_CONTRACTS
 else
   # The scripts/dockerfile COPY directive expects the nitro-contracts dir
   # to be there even if it is empty.
-  rm -rf scripts/nitro-contracts
   mkdir scripts/nitro-contracts
 fi
 
@@ -401,11 +400,6 @@ fi
 
 if $build_node_images; then
     docker compose build --no-rm $NODES scripts
-fi
-
-# Clean up nitro-contracts dir needed by scripts dockerfile.
-if [ -d scripts/nitro-contracts ]; then
-  rm -rf scripts/nitro-contracts
 fi
 
 if $force_init; then

--- a/test-node.bash
+++ b/test-node.bash
@@ -5,8 +5,7 @@ set -eu
 NITRO_NODE_VERSION=offchainlabs/nitro-node:v3.2.1-d81324d-dev
 BLOCKSCOUT_VERSION=offchainlabs/blockscout:v1.1.0-0e716c8
 
-# This commit matches v2.1.0 release of nitro-contracts, with additional support to set arb owner through upgrade executor
-DEFAULT_NITRO_CONTRACTS_VERSION="bec7d629c5f4a9dc4ec786e9d6e99734a11d109b"
+DEFAULT_NITRO_CONTRACTS_VERSION="v2.1.1"
 DEFAULT_TOKEN_BRIDGE_VERSION="v1.2.2"
 
 # Set default versions if not overriden by provided env vars
@@ -357,17 +356,6 @@ if $dev_blockscout && $build_dev_blockscout; then
     echo == Building Blockscout
     docker build blockscout -t blockscout -f blockscout/docker/Dockerfile
   fi
-fi
-
-# Use dev contracts when building scripts. See scripts/Dockerfile
-rm -rf scripts/nitro-contracts
-if ($build_utils || $build_node_images) && $dev_contracts; then
-  cp -ar ../contracts scripts/nitro-contracts
-  touch scripts/nitro-contracts/DEV_CONTRACTS
-else
-  # The scripts/dockerfile COPY directive expects the nitro-contracts dir
-  # to be there even if it is empty.
-  mkdir scripts/nitro-contracts
 fi
 
 if $build_utils; then

--- a/test-node.bash
+++ b/test-node.bash
@@ -360,9 +360,13 @@ if $dev_blockscout && $build_dev_blockscout; then
 fi
 
 # Use dev contracts when building scripts. See scripts/Dockerfile
-# TODO handle non --dev-contracts case properly - dockerfile COPY expects dir to be there.
 if ($build_utils || $build_node_images) && $dev_contracts; then
   cp -ar ../contracts scripts/nitro-contracts
+  touch scripts/nitro-contracts/DEV_CONTRACTS
+else
+  # The scripts/dockerfile COPY directive expects the nitro-contracts dir
+  # to be there even if it is empty.
+  mkdir scripts/nitro-contracts
 fi
 
 if $build_utils; then
@@ -397,7 +401,8 @@ if $build_node_images; then
     docker compose build --no-rm $NODES scripts
 fi
 
-if ($build_utils || $build_node_images) && $dev_contracts; then
+# Clean up nitro-contracts dir needed by scripts dockerfile.
+if [ -d scripts/nitro-contracts ]; then
   rm -rf scripts/nitro-contracts
 fi
 

--- a/test-node.bash
+++ b/test-node.bash
@@ -6,7 +6,7 @@ NITRO_NODE_VERSION=offchainlabs/nitro-node:v3.2.1-d81324d-dev
 BLOCKSCOUT_VERSION=offchainlabs/blockscout:v1.1.0-0e716c8
 
 # This commit matches v2.1.0 release of nitro-contracts, with additional support to set arb owner through upgrade executor
-DEFAULT_NITRO_CONTRACTS_VERSION="a815490fce7c7869f026df88efb437856caa46d8" # TODO express lane latest
+DEFAULT_NITRO_CONTRACTS_VERSION="99c07a7db2fcce75b751c5a2bd4936e898cda065"
 DEFAULT_TOKEN_BRIDGE_VERSION="v1.2.2"
 
 # Set default versions if not overriden by provided env vars

--- a/test-node.bash
+++ b/test-node.bash
@@ -361,11 +361,13 @@ fi
 
 # Use dev contracts when building scripts. See scripts/Dockerfile
 if ($build_utils || $build_node_images) && $dev_contracts; then
+  rm -rf scripts/nitro-contracts
   cp -ar ../contracts scripts/nitro-contracts
   touch scripts/nitro-contracts/DEV_CONTRACTS
 else
   # The scripts/dockerfile COPY directive expects the nitro-contracts dir
   # to be there even if it is empty.
+  rm -rf scripts/nitro-contracts
   mkdir scripts/nitro-contracts
 fi
 

--- a/test-node.bash
+++ b/test-node.bash
@@ -6,7 +6,7 @@ NITRO_NODE_VERSION=offchainlabs/nitro-node:v3.2.1-d81324d-dev
 BLOCKSCOUT_VERSION=offchainlabs/blockscout:v1.1.0-0e716c8
 
 # This commit matches v2.1.0 release of nitro-contracts, with additional support to set arb owner through upgrade executor
-DEFAULT_NITRO_CONTRACTS_VERSION="99c07a7db2fcce75b751c5a2bd4936e898cda065"
+DEFAULT_NITRO_CONTRACTS_VERSION="bec7d629c5f4a9dc4ec786e9d6e99734a11d109b"
 DEFAULT_TOKEN_BRIDGE_VERSION="v1.2.2"
 
 # Set default versions if not overriden by provided env vars

--- a/test-node.bash
+++ b/test-node.bash
@@ -460,7 +460,11 @@ if $force_init; then
 
     echo == Deploying L2 chain
     docker compose run -e PARENT_CHAIN_RPC="http://geth:8545" -e DEPLOYER_PRIVKEY=$l2ownerKey -e PARENT_CHAIN_ID=$l1chainid -e CHILD_CHAIN_NAME="arb-dev-test" -e MAX_DATA_SIZE=117964 -e OWNER_ADDRESS=$l2ownerAddress -e WASM_MODULE_ROOT=$wasmroot -e SEQUENCER_ADDRESS=$sequenceraddress -e AUTHORIZE_VALIDATORS=10 -e CHILD_CHAIN_CONFIG_PATH="/config/l2_chain_config.json" -e CHAIN_DEPLOYMENT_INFO="/config/deployment.json" -e CHILD_CHAIN_INFO="/config/deployed_chain_info.json" rollupcreator create-rollup-testnode
-    docker compose run --entrypoint sh rollupcreator -c "jq [.[]] /config/deployed_chain_info.json > /config/l2_chain_info.json"
+    if $l2timeboost; then
+        docker compose run --entrypoint sh rollupcreator -c 'jq ".[] | .\"track-block-metadata-from\"=1 | [.]" /config/deployed_chain_info.json > /config/l2_chain_info.json'
+    else
+        docker compose run --entrypoint sh rollupcreator -c "jq [.[]] /config/deployed_chain_info.json > /config/l2_chain_info.json"
+    fi
 
 fi # $force_init
 

--- a/test-node.bash
+++ b/test-node.bash
@@ -2,7 +2,7 @@
 
 set -eu
 
-NITRO_NODE_VERSION=offchainlabs/nitro-node:v3.2.1-d81324d-dev
+NITRO_NODE_VERSION=offchainlabs/nitro-node:v3.5.1-rc.2-69577b7
 BLOCKSCOUT_VERSION=offchainlabs/blockscout:v1.1.0-0e716c8
 
 DEFAULT_NITRO_CONTRACTS_VERSION="v2.1.1"

--- a/test-node.bash
+++ b/test-node.bash
@@ -532,7 +532,7 @@ if $force_init; then
         docker compose run scripts transfer-erc20 --token $biddingTokenAddress --amount 10000 --from auctioneer --to user_bob
 
         docker compose run --entrypoint sh scripts -c "sed -i 's/\(\"execution\":{\"sequencer\":{\"enable\":true,\"timeboost\":{\"enable\":\)false/\1true,\"auction-contract-address\":\"$auctionContractAddress\",\"auctioneer-address\":\"$auctioneerAddress\"/' /config/sequencer_config.json" --wait
-        docker compose restart sequencer
+        docker compose restart $INITIAL_SEQ_NODES
     fi
 
     if $tokenbridge; then

--- a/test-node.bash
+++ b/test-node.bash
@@ -535,7 +535,7 @@ if $force_init; then
         docker compose run scripts transfer-erc20 --token $biddingTokenAddress --amount 10000 --from auctioneer --to user_alice
         docker compose run scripts transfer-erc20 --token $biddingTokenAddress --amount 10000 --from auctioneer --to user_bob
 
-        docker compose run --entrypoint sh scripts -c "sed -i 's/\(\"execution\":{\"sequencer\":{\"enable\":true,\"timeboost\":{\"enable\":\)false/\1true,\"auction-contract-address\":\"$auctionContractAddress\",\"auctioneer-address\":\"$auctioneerAddress\"/' /config/sequencer_config.json" --wait
+        docker compose run --entrypoint sh scripts -c "sed -i 's/\(\"execution\":{\"sequencer\":{\"enable\":true,\"dangerous\":{\"timeboost\":{\"enable\":\)false/\1true,\"auction-contract-address\":\"$auctionContractAddress\",\"auctioneer-address\":\"$auctioneerAddress\"/' /config/sequencer_config.json" --wait
         docker compose restart $INITIAL_SEQ_NODES
     fi
 


### PR DESCRIPTION
This PR adds support for timeboost mode on nitro-testnode. It starts the bid-validator, autonomous auctioneer, deploys the ExpressLaneAuction contract, and starts the sequencer in Timeboost mode.

Since Timeboost is not yet merged into the master nitro branch, currently you will need to follow the following steps to run nitro-testnode in Timeboost mode. (If you had followed these instructions before note that this now no longer requires special steps with the nitro-contracts package as a version with timeboost is now released.)

* checkout nitro, branch: express-lane-timeboost
* In the nitro dir, go into the nitro-testnode submodule and check out timeboost-mode
  * From this directory, run ```./test-node.bash --init-force --dev --l2-timeboost```


When starting up, look for the line printing the token and contract address: 
```
== Bidding token: $biddingTokenAddress, auction contract $auctionContractAddress
```

You can also find the auction contract and auctioneer address with the following command.
```
$ docker compose run --entrypoint sh sequencer -c "cat /config/sequencer_config.json" | jq .execution.sequencer
 ✔ Container nitro-testnode-geth-1  Running0.0s 
{
  "enable": true,
  "timeboost": {
    "enable": true,
    "auction-contract-address": "0x7DD3F2a3fAeF3B9F2364c335163244D3388Feb83",
    "auctioneer-address": "0x46225F4cee2b4A1d506C7f894bb3dAeB21BF1596"
  }
}
```

Users alice and bob have been pre-funded with some of the bidding token on L2 and can be used right away.
```
$ docker compose run scripts print-private-key --account user_alice
...
$ docker compose run scripts print-private-key --account user_bob
...

# make a deposit into the ExpressLaneAuction contract
$ docker compose run  --entrypoint /usr/local/bin/bidder-client timeboost-bid-validator --auction-contract-address 0x... --deposit-gwei 1000000000  --wallet.private-key <alice or bob private key, no 0x> --arbitrum-node-endpoint http://sequencer:8547

# make a bid for control of the next express lane round
$ docker compose run  --entrypoint /usr/local/bin/bidder-client timeboost-bid-validator --auction-contract-address 0x... --bid-gwei 1 --wallet.private-key <alice or bob private key, no 0x> --arbitrum-node-endpoint http://sequencer:8547 --bid-validator-endpoint http://timeboost-bid-validator:8547 
```

Commands for sending express lane transactions will be provided in future, see [implementation](https://github.com/OffchainLabs/nitro/pull/2561) and [spec](https://github.com/OffchainLabs/timeboost-design/blob/main/research_spec.md) .