### PR TITLE
feat: bold upgrader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,4 @@ jobs:
           driver-opts: network=host
 
       - name: Startup Nitro testnode
-        run: ${{ github.workspace }}/.github/workflows/testnode.bash --init-force --bold-upgrade --simple
+        run: ${{ github.workspace }}/.github/workflows/testnode.bash --init-force --bold-upgrade --simple --detach

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,20 @@ jobs:
 
       - name: Startup Nitro testnode
         run: ${{ github.workspace }}/.github/workflows/testnode.bash --init-force ${{ (matrix.l3node == 'l3node' && '--l3node') || (matrix.l3node == 'l3node-token-6' && '--l3node --l3-fee-token --l3-token-bridge --l3-fee-token-decimals 6') || '' }} ${{ matrix.tokenbridge == 'tokenbridge' && '--tokenbridge' || '--no-tokenbridge' }} --detach ${{ matrix.pos == 'pos' && '--pos' || '' }} --simple ${{ (matrix.simple == 'simple' && '--simple') || (matrix.simple == 'no-simple' && '--no-simple') || '' }}
+
+  bold_upgrade:
+    runs-on: ubuntu-8
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
+
+      - name: Startup Nitro testnode
+        run: ${{ github.workspace }}/.github/workflows/testnode.bash --init-force --bold-upgrade --simple

--- a/boldupgrader/Dockerfile
+++ b/boldupgrader/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:18-bullseye-slim
+RUN apt-get update && \
+    apt-get install -y git docker.io python3 make gcc g++ curl jq
+ARG BOLD_CONTRACTS_BRANCH=bold-merge-script
+WORKDIR /workspace  
+RUN git clone --no-checkout https://github.com/OffchainLabs/nitro-contracts.git ./
+RUN git checkout ${BOLD_CONTRACTS_BRANCH}
+RUN yarn install && yarn cache clean
+RUN curl -L https://foundry.paradigm.xyz | bash
+ENV PATH="${PATH}:/root/.foundry/bin"
+RUN foundryup
+RUN touch scripts/config.ts
+RUN yarn build:all
+ENTRYPOINT ["yarn"]

--- a/docker-compose-ci-cache.json
+++ b/docker-compose-ci-cache.json
@@ -22,6 +22,17 @@
         "type=docker"
       ]
     },
+    "boldupgrader": {
+      "cache-from": [
+        "type=local,src=/tmp/.buildx-cache"
+      ],
+      "cache-to": [
+        "type=local,dest=/tmp/.buildx-cache,mode=max"
+      ],
+      "output": [
+        "type=docker"
+      ]
+    },
     "tokenbridge": {
       "cache-from": [
         "type=local,src=/tmp/.buildx-cache"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -354,6 +354,26 @@ services:
       - "tokenbridge-data:/workspace"
       - /var/run/docker.sock:/var/run/docker.sock
 
+  boldupgrader:
+    depends_on:
+      - geth
+      - sequencer
+    pid: host
+    build:
+      context: boldupgrader/
+      args:
+        BOLD_CONTRACTS_BRANCH: ${BOLD_CONTRACTS_BRANCH:-}
+    environment:
+      - L1_RPC_URL=http://geth:8545
+      - L1_PRIV_KEY=0xdc04c5399f82306ec4b4d654a342f40e2e0620fe39950d967e1e574b32d4dd36
+      - CONFIG_NETWORK_NAME=local
+      - DEPLOYED_CONTRACTS_DIR=./scripts/files/
+      - DISABLE_VERIFICATION=true
+    volumes:
+      - "config:/config"
+      - "boldupgrader-data:/workspace"
+      - /var/run/docker.sock:/var/run/docker.sock
+
   rollupcreator:
     depends_on:
       - geth
@@ -383,3 +403,4 @@ volumes:
   config:
   postgres-data:
   tokenbridge-data:
+  boldupgrader-data:

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -14,6 +14,7 @@ import {
   bridgeNativeTokenToL3Command,
   bridgeToL3Command,
   createERC20Command,
+  createWETHCommand,
   transferERC20Command,
   sendL1Command,
   sendL2Command,
@@ -38,6 +39,7 @@ async function main() {
     .command(bridgeToL3Command)
     .command(bridgeNativeTokenToL3Command)
     .command(createERC20Command)
+    .command(createWETHCommand)
     .command(transferERC20Command)
     .command(sendL1Command)
     .command(sendL2Command)

--- a/test-node.bash
+++ b/test-node.bash
@@ -5,11 +5,11 @@ set -eu
 NITRO_NODE_VERSION=offchainlabs/nitro-node:v3.2.1-d81324d-dev
 BLOCKSCOUT_VERSION=offchainlabs/blockscout:v1.1.0-0e716c8
 
-# This commit matches v2.1.0 release of nitro-contracts, with additional support to set arb owner through upgrade executor
-DEFAULT_NITRO_CONTRACTS_VERSION="v2.1.1-beta.0"
-DEFAULT_BOLD_CONTRACTS_VERSION="7d028430"
-# bold-merge-script
+DEFAULT_NITRO_CONTRACTS_VERSION="v2.1.0"
 DEFAULT_TOKEN_BRIDGE_VERSION="v1.2.2"
+
+# The is the latest bold-merge commit in nitro-contracts at the time
+DEFAULT_BOLD_CONTRACTS_VERSION="59d3cbd"
 
 # Set default versions if not overriden by provided env vars
 : ${NITRO_CONTRACTS_BRANCH:=$DEFAULT_NITRO_CONTRACTS_VERSION}

--- a/test-node.bash
+++ b/test-node.bash
@@ -6,7 +6,7 @@ NITRO_NODE_VERSION=offchainlabs/nitro-node:v3.2.1-d81324d-dev
 BLOCKSCOUT_VERSION=offchainlabs/blockscout:v1.1.0-0e716c8
 
 # This commit matches v2.1.0 release of nitro-contracts, with additional support to set arb owner through upgrade executor
-DEFAULT_NITRO_CONTRACTS_VERSION="v2.1.1-beta.0"
+DEFAULT_NITRO_CONTRACTS_VERSION="d76f3a11"
 DEFAULT_BOLD_CONTRACTS_VERSION="ef08baca"
 # bold-merge-script
 DEFAULT_TOKEN_BRIDGE_VERSION="v1.2.2"

--- a/test-node.bash
+++ b/test-node.bash
@@ -497,10 +497,10 @@ if $force_init; then
     docker compose run -e CHILD_CHAIN_RPC="http://sequencer:8547" -e CHAIN_OWNER_PRIVKEY=$l2ownerKey rollupcreator deploy-cachemanager-testnode
 
     if $boldupgrade; then
-        echo == Deploying BOLD stake token
-        stakeTokenAddress=`docker compose run scripts create-erc20 --l1 --deployer l2owner --decimals 18 | tail -n 1 | awk '{ print $NF }'`
+        echo == Deploying WETH as BOLD stake token
+        stakeTokenAddress=`docker compose run scripts create-weth --deployer l2owner --deposit 100 | tail -n 1 | awk '{ print $NF }'`
         echo BOLD stake token address: $stakeTokenAddress
-        docker compose run scripts transfer-erc20 --token $stakeTokenAddress --l1 --amount 10000 --from l2owner --to validator
+        docker compose run scripts transfer-erc20 --token $stakeTokenAddress --l1 --amount 100 --from l2owner --to validator
         echo == Preparing BOLD upgrade
         docker compose run -e TESTNODE_MODE=true -e ROLLUP_ADDRESS=$rollupAddress -e STAKE_TOKEN=$stakeTokenAddress boldupgrader script:bold-prepare
         # retry this 10 times because the staker might not have made a node yet

--- a/test-node.bash
+++ b/test-node.bash
@@ -7,7 +7,7 @@ BLOCKSCOUT_VERSION=offchainlabs/blockscout:v1.1.0-0e716c8
 
 # This commit matches v2.1.0 release of nitro-contracts, with additional support to set arb owner through upgrade executor
 DEFAULT_NITRO_CONTRACTS_VERSION="v2.1.1-beta.0"
-DEFAULT_BOLD_CONTRACTS_VERSION="a6e2e598"
+DEFAULT_BOLD_CONTRACTS_VERSION="ef08baca"
 # bold-merge-script
 DEFAULT_TOKEN_BRIDGE_VERSION="v1.2.2"
 

--- a/test-node.bash
+++ b/test-node.bash
@@ -498,7 +498,7 @@ if $force_init; then
 
     if $boldupgrade; then
         echo == Deploying BOLD stake token
-        stakeTokenAddress=`docker compose run scripts create-erc20 --deployer l2owner --decimals 18 | tail -n 1 | awk '{ print $NF }'`
+        stakeTokenAddress=`docker compose run scripts create-erc20 --l1 --deployer l2owner --decimals 18 | tail -n 1 | awk '{ print $NF }'`
         echo BOLD stake token address: $stakeTokenAddress
         docker compose run scripts transfer-erc20 --token $stakeTokenAddress --amount 10000 --from l2owner --to validator
         echo == Preparing BOLD upgrade

--- a/test-node.bash
+++ b/test-node.bash
@@ -5,7 +5,7 @@ set -eu
 NITRO_NODE_VERSION=offchainlabs/nitro-node:v3.2.1-d81324d-dev
 BLOCKSCOUT_VERSION=offchainlabs/blockscout:v1.1.0-0e716c8
 
-DEFAULT_NITRO_CONTRACTS_VERSION="v2.1.0"
+DEFAULT_NITRO_CONTRACTS_VERSION="v2.1.1-beta.0"
 DEFAULT_TOKEN_BRIDGE_VERSION="v1.2.2"
 
 # The is the latest bold-merge commit in nitro-contracts at the time

--- a/test-node.bash
+++ b/test-node.bash
@@ -499,7 +499,12 @@ if $force_init; then
     if $boldupgrade; then
         echo == Preparing BOLD upgrade
         docker compose run boldupgrader script:bold-prepare
-        docker compose run boldupgrader script:bold-populate-lookup
+        # retry this 10 times because the staker might not have made a node yet
+        for i in {1..10}; do
+            docker compose run boldupgrader script:bold-populate-lookup && break || true
+            echo "Failed to populate lookup table, retrying..."
+            sleep 10
+        done
         docker compose run boldupgrader script:bold-local-execute
     fi
 

--- a/test-node.bash
+++ b/test-node.bash
@@ -6,7 +6,7 @@ NITRO_NODE_VERSION=offchainlabs/nitro-node:v3.2.1-d81324d-dev
 BLOCKSCOUT_VERSION=offchainlabs/blockscout:v1.1.0-0e716c8
 
 # This commit matches v2.1.0 release of nitro-contracts, with additional support to set arb owner through upgrade executor
-DEFAULT_NITRO_CONTRACTS_VERSION="d76f3a11"
+DEFAULT_NITRO_CONTRACTS_VERSION="7fd211e9"
 DEFAULT_BOLD_CONTRACTS_VERSION="ef08baca"
 # bold-merge-script
 DEFAULT_TOKEN_BRIDGE_VERSION="v1.2.2"

--- a/test-node.bash
+++ b/test-node.bash
@@ -6,7 +6,7 @@ NITRO_NODE_VERSION=offchainlabs/nitro-node:v3.2.1-d81324d-dev
 BLOCKSCOUT_VERSION=offchainlabs/blockscout:v1.1.0-0e716c8
 
 # This commit matches v2.1.0 release of nitro-contracts, with additional support to set arb owner through upgrade executor
-DEFAULT_NITRO_CONTRACTS_VERSION="7fd211e9"
+DEFAULT_NITRO_CONTRACTS_VERSION="984aff18"
 DEFAULT_BOLD_CONTRACTS_VERSION="ef08baca"
 # bold-merge-script
 DEFAULT_TOKEN_BRIDGE_VERSION="v1.2.2"

--- a/test-node.bash
+++ b/test-node.bash
@@ -9,7 +9,7 @@ DEFAULT_NITRO_CONTRACTS_VERSION="v2.1.1-beta.0"
 DEFAULT_TOKEN_BRIDGE_VERSION="v1.2.2"
 
 # The is the latest bold-merge commit in nitro-contracts at the time
-DEFAULT_BOLD_CONTRACTS_VERSION="2f1d58dc"
+DEFAULT_BOLD_CONTRACTS_VERSION="42d80e40"
 
 # Set default versions if not overriden by provided env vars
 : ${NITRO_CONTRACTS_BRANCH:=$DEFAULT_NITRO_CONTRACTS_VERSION}

--- a/test-node.bash
+++ b/test-node.bash
@@ -500,7 +500,7 @@ if $force_init; then
         echo == Deploying BOLD stake token
         stakeTokenAddress=`docker compose run scripts create-erc20 --l1 --deployer l2owner --decimals 18 | tail -n 1 | awk '{ print $NF }'`
         echo BOLD stake token address: $stakeTokenAddress
-        docker compose run scripts transfer-erc20 --token $stakeTokenAddress --amount 10000 --from l2owner --to validator
+        docker compose run scripts transfer-erc20 --token $stakeTokenAddress --l1 --amount 10000 --from l2owner --to validator
         echo == Preparing BOLD upgrade
         docker compose run -e TESTNODE_MODE=true -e ROLLUP_ADDRESS=$rollupAddress -e STAKE_TOKEN=$stakeTokenAddress boldupgrader script:bold-prepare
         # retry this 10 times because the staker might not have made a node yet


### PR DESCRIPTION
This PR introduce `--bold-upgrade` flag to perform BOLD upgrade on top of a nitro-contract v2.1 deployment. 
Only L2 testnode is supported (i.e. --l3-node will not be upgraded).
```shell
$ ./test-node.bash --init-force --no-tokenbridge --bold-upgrade
...
upgrade executed
upgrade tx hash: 0x609083720b76357c30c8c9a56be80d9364ad742ccdbe1c09a27e35b51ed1af6d
verifying the upgrade...
Old Rollup: 0x3A052fF29EAFdd226Df1C4824d51A56a8Ad5D7A4
BOLD Rollup: 0x01C2d0aac633f35c99C675f85e7A0e11b1F8Ff8E
BOLD Challenge Manager: 0xF2aB168E46C4473424804D1d568548decA7faB95
BOLD AssertionCreated assertionHash: 0x47a95b5265fdf69ba6d268fb4001fb59cd68224c7038a1c8ff4d43945621bf89
BOLD AssertionCreated parentAssertionHash: 0x0000000000000000000000000000000000000000000000000000000000000000
BOLD AssertionCreated assertion: [["0x0000000000000000000000000000000000000000000000000000000000000000","0x0000000000000000000000000000000000000000000000000000000000000000",["0x0000000000000000000000000000000000000000000000000000000000000000",{"type":"BigNumber","hex":"0x00"},"0x0000000000000000000000000000000000000000",{"type":"BigNumber","hex":"0x00"},{"type":"BigNumber","hex":"0x00"}]],[[["0x0000000000000000000000000000000000000000000000000000000000000000","0x0000000000000000000000000000000000000000000000000000000000000000"],[{"type":"BigNumber","hex":"0x00"},{"type":"BigNumber","hex":"0x00"}]],0,"0x0000000000000000000000000000000000000000000000000000000000000000"],[[["0x8d8f824fc8de64f5c1d14bd4028c868df8022f41aba6c5baf2a9f48b68330349","0x0000000000000000000000000000000000000000000000000000000000000000"],[{"type":"BigNumber","hex":"0x02"},{"type":"BigNumber","hex":"0x00"}]],1,"0x0000000000000000000000000000000000000000000000000000000000000000"]]
BOLD AssertionCreated afterInboxBatchAcc: 0x0000000000000000000000000000000000000000000000000000000000000000
BOLD AssertionCreated inboxMaxCount: BigNumber { _hex: '0x03', _isBigNumber: true }
BOLD AssertionCreated wasmModuleRoot: 0x0581713e5c78e7b069e46f5ea128707459f49b88bd33a56cee78179b7424814b
BOLD AssertionCreated requiredStake: BigNumber { _hex: '0x0de0b6b3a7640000', _isBigNumber: true }
BOLD AssertionCreated challengeManager: 0xF2aB168E46C4473424804D1d568548decA7faB95
BOLD AssertionCreated confirmPeriodBlocks: BigNumber { _hex: '0x64', _isBigNumber: true }
oldLatestConfirmedStateHash 0xfd3ee9b525874822bd6661533e936d727cd3cec225abde0f5fef9e46b3a8a803
BOLD latest confirmed: 0x47a95b5265fdf69ba6d268fb4001fb59cd68224c7038a1c8ff4d43945621bf89
upgrade verified
```

run these command without using the `--bold-upgrade` flag to better control the upgrade timing
```
$ stakeTokenAddress=`docker compose run scripts create-weth --deployer l2owner --deposit 100 | tail -n 1 | awk '{ print $NF }'`
$ docker compose run scripts transfer-erc20 --token $stakeTokenAddress --l1 --amount 100 --from l2owner --to validator
$ rollupAddress=`docker compose run --entrypoint sh poster -c "jq -r '.[0].rollup.rollup' /config/deployed_chain_info.json | tail -n 1 | tr -d '\r\n'"`
$ docker compose run -e TESTNODE_MODE=true -e ROLLUP_ADDRESS=$rollupAddress -e STAKE_TOKEN=$stakeTokenAddress boldupgrader script:bold-prepare
$ docker compose run -e TESTNODE_MODE=true -e ROLLUP_ADDRESS=$rollupAddress -e STAKE_TOKEN=$stakeTokenAddress boldupgrader script:bold-populate-lookup
$ docker compose run -e TESTNODE_MODE=true -e ROLLUP_ADDRESS=$rollupAddress -e STAKE_TOKEN=$stakeTokenAddress boldupgrader script:bold-local-execute
```

during the BOLD upgrade, a new stakeToken weth would be deployed by `l2owner` and the`validator` address would start with a balance of 100

Depending on https://github.com/OffchainLabs/nitro-contracts/pull/263