### PR TITLE
Set ensure-rollup-deployment to false

### DIFF
--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -177,6 +177,7 @@ function writeConfigs(argv: any) {
     const valJwtSecret = path.join(consts.configpath, "val_jwt.hex")
     const chainInfoFile = path.join(consts.configpath, "l2_chain_info.json")
     let baseConfig = {
+        "ensure-rollup-deployment": false,
         "parent-chain": {
             "connection": {
                 "url": argv.l1url,


### PR DESCRIPTION
Disable this feature because the testnode doesn't support finalized blocks.