### PR TITLE
Fix Typo in `test-node.bash

### DIFF
--- a/test-node.bash
+++ b/test-node.bash
@@ -11,7 +11,7 @@ DEFAULT_TOKEN_BRIDGE_VERSION="v1.2.2"
 # The is the latest bold-merge commit in nitro-contracts at the time
 DEFAULT_BOLD_CONTRACTS_VERSION="42d80e40"
 
-# Set default versions if not overriden by provided env vars
+# Set default versions if not overridden by provided env vars
 : ${NITRO_CONTRACTS_BRANCH:=$DEFAULT_NITRO_CONTRACTS_VERSION}
 : ${BOLD_CONTRACTS_BRANCH:=$DEFAULT_BOLD_CONTRACTS_VERSION}
 : ${TOKEN_BRIDGE_BRANCH:=$DEFAULT_TOKEN_BRIDGE_VERSION}


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `test-node.bash`**

## Description  
This pull request addresses a typo in the `test-node.bash` file where the word "overriden" is corrected to "overridden" to match the proper English spelling.

### Changes Made:
- **File Modified:** `test-node.bash`
- **Summary of Changes:**  
  - Corrected the typo:  
    `"overriden"` → `"overridden"`

## Checklist  
- [x] Fixed the typo in the comment.
- [x] Verified that the change does not affect functionality.
- [x] Complied with the project’s coding standards.

## Additional Notes  
This change ensures the comment uses correct spelling, improving readability and professionalism.

---

**Allow edits by maintainers:** [x]
