### PR TITLE
Run ci nightly for the release branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
       - master
       - develop
       - release
+  # run this job on the default branch daily
+  # the docker compose file contains some images with tags like 'latest' and 'stable'
+  # we nightly run here just to double check no bugs have been merged into those tags and are now on release
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   build_and_run:


### PR DESCRIPTION
It seems the prysm config creation is currently failing on the :latest image. We use a bunch of :latest and :stable images in the docker compose. We could switch those to specific tags, but then we may not stay up to date. Whilst we decide if we want to do that I've add a schedule to run ci on the release branch every night in case one of those images is updated to contain a bug.