### PR TITLE
Fixes: blobSchedule for cancun, --allow=fs=/tmp in docker buildx bake

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -98,7 +98,6 @@ services:
       - --output-ssz=/consensus/genesis.ssz
       - --chain-config-file=/config/prysm.yaml
       - --geth-genesis-json-in=/config/geth_genesis.json
-      - --geth-genesis-json-out=/config/geth_genesis.json
     volumes:
       - "consensus:/consensus"
       - "config:/config"

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -72,7 +72,14 @@ function writeGethGenesisConfig(argv: any) {
                 "shanghaiTime": 0,
                 "cancunTime": 1706778826,
                 "terminalTotalDifficulty": 0,
-                "terminalTotalDifficultyPassed": true
+                "terminalTotalDifficultyPassed": true,
+                "blobSchedule": {
+                    "cancun": {
+                        "target": 3,
+                        "max": 6,
+                        "baseFeeUpdateFraction": 3338477
+                    }
+                }
         },
         "difficulty": "0",
         "extradata": "0x00000000000000000000000000000000000000000000000000000000000000003f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E0B0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",

--- a/test-node.bash
+++ b/test-node.bash
@@ -375,7 +375,7 @@ if $build_utils; then
 
   if [ "$ci" == true ]; then
     # workaround to cache docker layers and keep using docker-compose in CI
-    docker buildx bake --file docker-compose.yaml --file docker-compose-ci-cache.json $LOCAL_BUILD_NODES
+    docker buildx bake --allow=fs=/tmp --file docker-compose.yaml --file docker-compose-ci-cache.json $LOCAL_BUILD_NODES
   else
     UTILS_NOCACHE=""
     if $force_build_utils; then


### PR DESCRIPTION
- Adds blobSchedule for cancun, which avoids the `unsupported fork configuration: missing blob configuration entry for cancun in schedule`issue

- Adds `--allow=fs=/tmp` in docker buildx bake, which avoids the `ERROR: additional privileges requested`issue

- Removes `--geth-genesis-json-out=/config/geth_genesis.json` from create_beacon_chain_genesis. Current latest version of prymsctl depends on go-ethereum@v1.14.13, however BlobScheduleConfig was only introduced in go-ethereum@v1.15.0. With the `--geth-genesis-json-out` flag set, prysmctl generate a config without BlobScheduleConfig, which is required down the line.