### PR TITLE
add flag to set max code and init code size

### DIFF
--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -347,6 +347,8 @@ function writeConfigs(argv: any) {
     l3Config.node["delayed-sequencer"]["use-merge-finality"] = false
     l3Config.node["batch-poster"].enable = true
     l3Config.node["batch-poster"]["redis-url"] = ""
+    l3Config.node["delayed-sequencer"]["MaxCodeSize"] = argv.maxCodeSize
+    l3Config.node["delayed-sequencer"]["MaxInitCodeSize"] = argv.maxInitCodeSize
     fs.writeFileSync(path.join(consts.configpath, "l3node_config.json"), JSON.stringify(l3Config))
 
     let validationNodeConfig = JSON.parse(JSON.stringify({
@@ -397,7 +399,9 @@ function writeL2ChainConfig(argv: any) {
             "DataAvailabilityCommittee": argv.anytrust,
             "InitialArbOSVersion": 32,
             "InitialChainOwner": argv.l2owner,
-            "GenesisBlockNum": 0
+            "GenesisBlockNum": 0,
+            "MaxCodeSize": argv.maxCodeSize,
+            "MaxInitCodeSize": argv.maxInitCodeSize
         }
     }
     const l2ChainConfigJSON = JSON.stringify(l2ChainConfig)
@@ -430,7 +434,9 @@ function writeL3ChainConfig(argv: any) {
             "DataAvailabilityCommittee": false,
             "InitialArbOSVersion": 31,
             "InitialChainOwner": argv.l2owner,
-            "GenesisBlockNum": 0
+            "GenesisBlockNum": 0,
+            "MaxCodeSize": argv.maxCodeSize,
+            "MaxInitCodeSize": argv.maxInitCodeSize
         }
     }
     const l3ChainConfigJSON = JSON.stringify(l3ChainConfig)
@@ -548,6 +554,16 @@ export const writeConfigCommand = {
             describe: "DAS committee member B BLS pub key",
             default: ""
         },
+        maxCodeSize: {
+            number: true,
+            describe: "maximum code size for contracts",
+            default: 24576
+        },
+        maxInitCodeSize: {
+            number: true,
+            describe: "maximum init code size for contract creation",
+            default: 49152
+        },
 
       },
     handler: (argv: any) => {
@@ -580,6 +596,16 @@ export const writeL2ChainConfigCommand = {
             describe: "enable anytrust in chainconfig",
             default: false
         },
+        maxCodeSize: {
+            number: true,
+            describe: "maximum code size for contracts",
+            default: 24576
+        },
+        maxInitCodeSize: {
+            number: true,
+            describe: "maximum init code size for contract creation",
+            default: 49152
+        }
     },
     handler: (argv: any) => {
         writeL2ChainConfig(argv)
@@ -589,6 +615,23 @@ export const writeL2ChainConfigCommand = {
 export const writeL3ChainConfigCommand = {
     command: "write-l3-chain-config",
     describe: "writes l3 chain config file",
+    builder: {
+        anytrust: {
+            boolean: true,
+            describe: "enable anytrust in chainconfig",
+            default: false
+        },
+        maxCodeSize: {
+            number: true,
+            describe: "maximum code size for contracts",
+            default: 24576
+        },
+        maxInitCodeSize: {
+            number: true,
+            describe: "maximum init code size for contract creation",
+            default: 49152
+        }
+    },
     handler: (argv: any) => {
         writeL3ChainConfig(argv)
     }

--- a/test-node.bash
+++ b/test-node.bash
@@ -60,6 +60,8 @@ devprivkey=b6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659
 l1chainid=1337
 simple=true
 l2anytrust=false
+l2maxCodeSize=24576
+l2maxInitCodeSize=49152
 
 # Use the dev versions of nitro/blockscout
 dev_nitro=false
@@ -278,6 +280,16 @@ while [[ $# -gt 0 ]]; do
             simple=false
             shift
             ;;
+        --maxCodeSize)
+            l2maxCodeSize="$2"
+            shift
+            shift
+            ;;
+        --maxInitCodeSize)
+            l2maxInitCodeSize="$2"
+            shift
+            shift
+            ;;
         *)
             echo Usage: $0 \[OPTIONS..]
             echo        $0 script [SCRIPT-ARGS]
@@ -472,10 +484,10 @@ if $force_init; then
 
     if $l2anytrust; then
         echo "== Writing l2 chain config (anytrust enabled)"
-        docker compose run scripts --l2owner $l2ownerAddress  write-l2-chain-config --anytrust
+        docker compose run scripts --l2owner $l2ownerAddress  write-l2-chain-config --anytrust --maxCodeSize $l2maxCodeSize --maxInitCodeSize $l2maxInitCodeSize
     else
         echo == Writing l2 chain config
-        docker compose run scripts --l2owner $l2ownerAddress  write-l2-chain-config
+        docker compose run scripts --l2owner $l2ownerAddress  write-l2-chain-config --maxCodeSize $l2maxCodeSize --maxInitCodeSize $l2maxInitCodeSize
     fi
 
     sequenceraddress=`docker compose run scripts print-address --account sequencer | tail -n 1 | tr -d '\r\n'`
@@ -583,7 +595,7 @@ if $force_init; then
         echo == Writing l3 chain config
         l3owneraddress=`docker compose run scripts print-address --account l3owner | tail -n 1 | tr -d '\r\n'`
         echo l3owneraddress $l3owneraddress
-        docker compose run scripts --l2owner $l3owneraddress  write-l3-chain-config
+        docker compose run scripts --l2owner $l3owneraddress  write-l3-chain-config --maxCodeSize $l2maxCodeSize --maxInitCodeSize $l2maxInitCodeSize
 
         EXTRA_L3_DEPLOY_FLAG=""
         if $l3_custom_fee_token; then


### PR DESCRIPTION
Allows the test node to be configured with the following options

- `--maxCodeSize`: Maximum size of contract code in bytes (default: 24576)
- `--maxInitCodeSize`: Maximum size of contract initialization code in bytes (default: 49152)

Example:
```bash
./test-node.bash --init --dev --maxCodeSize 50000 --maxInitCodeSize 100000
```

Makes it easier to develop stylus contracts locally, so you can size golf later