### PR TITLE
chore: fixed duplicated .options() calls and improved parameter handling

### DIFF
--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -47,8 +47,8 @@ async function main() {
       validationNodeUrl: { string: true, default: "ws://validation_node:8549" },
       l2owner: { string: true, default: "0x3f1Eae7D46d88F08fc2F8ed27FCb2AB183EB2d0E" },
       committeeMember: { string: true, default: "not_set" },
+      ...stressOptions
     })
-    .options(stressOptions)
     .command(bridgeFundsCommand)
     .command(bridgeToL3Command)
     .command(bridgeNativeTokenToL3Command)


### PR DESCRIPTION
I’ve consolidated the .options() calls, so all parameters, including stressOptions, are now passed in a single call, eliminating redundancy.

I used the spread operator (...stressOptions) to correctly handle stressOptions when it's an object. All commands are now properly sequenced.

The code should work without errors if stressOptions is an object. If it's a function, it should be called as mentioned earlier.