### PR TITLE
update to bookworm

### DIFF
--- a/boldupgrader/Dockerfile
+++ b/boldupgrader/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bullseye-slim
+FROM node:18-bookworm-slim
 RUN apt-get update && \
     apt-get install -y git docker.io python3 make gcc g++ curl jq
 ARG BOLD_CONTRACTS_BRANCH=bold-merge-script

--- a/rollupcreator/Dockerfile
+++ b/rollupcreator/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bullseye-slim
+FROM node:18-bookworm-slim
 RUN apt-get update && \
     apt-get install -y git docker.io python3 make gcc g++ curl jq
 ARG NITRO_CONTRACTS_BRANCH=main

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Base build environment
-FROM node:18-bullseye-slim AS base
+FROM node:18-bookworm-slim AS base
 WORKDIR /workspace
 COPY ./package.json ./yarn.lock ./
 RUN yarn

--- a/tokenbridge/Dockerfile
+++ b/tokenbridge/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bullseye-slim
+FROM node:18-bookworm-slim
 RUN apt-get update && \
     apt-get install -y git docker.io python3 make gcc g++ curl jq
 ARG TOKEN_BRIDGE_BRANCH=main


### PR DESCRIPTION
on bullseye, installing the latest stable foundry produces the following error:

```
33.94 forge: /lib/x86_64-linux-gnu/libc.so.6: version GLIBC_2.33' not found (required by forge)
33.94 forge: /lib/x86_64-linux-gnu/libc.so.6: version GLIBC_2.32' not found (required by forge)
33.94 forge: /lib/x86_64-linux-gnu/libc.so.6: version GLIBC_2.34' not found (required by forge)
```

upgrading the base image to bookworm fixes the issue