### PR TITLE
Remove node.bold.strategy use node.staker.strategy instead

### DIFF
--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -200,7 +200,6 @@ function writeConfigs(argv: any) {
         "node": {
             "bold": {
                 "rpc-block-number": "latest",
-                "strategy": "makeNodes",
                 "assertion-posting-interval": "10s"
             },
             "staker": {


### PR DESCRIPTION
With NIT-3732 https://github.com/OffchainLabs/nitro/pull/3582

nitro-testnode only has to run ``--node.staker.strategy``, not both `--node.staker.strategy`` and `--node.bold.strategy``

This PR in OffchainLabs/nitro-testnode will make CI pass for https://github.com/OffchainLabs/nitro/pull/3582 docker CI