### PR TITLE
feat: make number of validators customizable

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -86,14 +86,13 @@ services:
 
   # Creates a genesis state for the beacon chain using a YAML configuration file and
   # a deterministic set of validators
-  # TODO: Make num validators customizable
   create_beacon_chain_genesis:
     image: "gcr.io/prysmaticlabs/prysm/cmd/prysmctl:latest"
     command:
       - testnet
       - generate-genesis
       - --fork=deneb
-      - --num-validators=64
+      - --num-validators=${NUM_VALIDATORS:-64}
       - --genesis-time-delay=15
       - --output-ssz=/consensus/genesis.ssz
       - --chain-config-file=/config/prysm.yaml
@@ -135,7 +134,7 @@ services:
       - "consensus:/consensus"
       - "config:/config"
 
-  # We run a validator client with 64, deterministically-generated keys that match
+  # We run a validator client with deterministically-generated keys that match
   # The validator keys present in the beacon chain genesis state generated a few steps above.
   prysm_validator:
     image: "gcr.io/prysmaticlabs/prysm/validator:stable"
@@ -143,7 +142,7 @@ services:
       - --beacon-rpc-provider=prysm_beacon_chain:5000
       - --datadir=/consensus/validatordata
       - --accept-terms-of-use
-      - --interop-num-validators=64
+      - --interop-num-validators=${NUM_VALIDATORS:-64}
       - --interop-start-index=0
       - --chain-config-file=/config/prysm.yaml
     depends_on:

--- a/test-node.bash
+++ b/test-node.bash
@@ -57,6 +57,7 @@ l1chainid=1337
 simple=true
 l2anytrust=false
 l2timeboost=false
+num_validators=64
 
 # Use the dev versions of nitro/blockscout
 dev_nitro=false
@@ -266,6 +267,15 @@ while [[ $# -gt 0 ]]; do
             l2timeboost=true
             shift
             ;;
+        --num-validators)
+            num_validators=$2
+            if ! [[ $num_validators =~ ^[0-9]+$ ]] || [ $num_validators -lt 1 ] || [ $num_validators -gt 1000 ]; then
+                echo "Error: num-validators must be a positive integer between 1 and 1000, got: $num_validators"
+                exit 1
+            fi
+            shift
+            shift
+            ;;
         --redundantsequencers)
             simple=false
             redundantsequencers=$2
@@ -310,6 +320,7 @@ while [[ $# -gt 0 ]]; do
             echo --l3-token-bridge Deploy L2-L3 token bridge. Only valid if also '--l3node' is provided
             echo --l2-anytrust     run the L2 as an AnyTrust chain
             echo --l2-timeboost    run the L2 with Timeboost enabled, including auctioneer and bid validator
+            echo --num-validators  number of validators for proof-of-stake consensus [1-1000] \(default: 64\)
             echo --batchposters    batch posters [0-3]
             echo --redundantsequencers redundant sequencers [0-3]
             echo --detach          detach from nodes after running them
@@ -333,6 +344,10 @@ while [[ $# -gt 0 ]]; do
             exit 0
     esac
 done
+
+# Export NUM_VALIDATORS for docker-compose
+export NUM_VALIDATORS=$num_validators
+echo "Using NUM_VALIDATORS: $NUM_VALIDATORS"
 
 NODES="sequencer"
 INITIAL_SEQ_NODES="sequencer"


### PR DESCRIPTION
- Add --num-validators parameter to test-node.bash with validation (1-1000)
- Update docker-compose.yaml to use NUM_VALIDATORS environment variable
- Remove hardcoded validator count of 64 in beacon chain setup
- Add proper help documentation for the new parameter

Resolves TODO: Make num validators customizable"