### PR TITLE
NIT-3941: Remove one-time containers

### DIFF
--- a/test-node.bash
+++ b/test-node.bash
@@ -23,9 +23,13 @@ echo "Using TOKEN_BRIDGE_BRANCH: $TOKEN_BRIDGE_BRANCH"
 mydir=`dirname $0`
 cd "$mydir"
 
+run_script() {
+  docker compose run --rm scripts "$@"
+}
+
 if [[ $# -gt 0 ]] && [[ $1 == "script" ]]; then
     shift
-    docker compose run --rm scripts "$@"
+    run_script "$@"
     exit $?
 fi
 
@@ -420,10 +424,6 @@ fi
 if $build_node_images; then
     docker compose build --no-rm $NODES
 fi
-
-run_script() {
-  docker compose run --rm scripts "$@"
-}
 
 if $force_init; then
     echo == Removing old data..

--- a/test-node.bash
+++ b/test-node.bash
@@ -421,6 +421,10 @@ if $build_node_images; then
     docker compose build --no-rm $NODES
 fi
 
+run_script() {
+  docker compose run --rm scripts "$@"
+}
+
 if $force_init; then
     echo == Removing old data..
     docker compose down
@@ -435,17 +439,17 @@ if $force_init; then
     fi
 
     echo == Generating l1 keys
-    docker compose run scripts write-accounts
+    run_script write-accounts
     docker compose run --entrypoint sh geth -c "echo passphrase > /datadir/passphrase"
     docker compose run --entrypoint sh geth -c "chown -R 1000:1000 /keystore"
     docker compose run --entrypoint sh geth -c "chown -R 1000:1000 /config"
 
     echo == Writing geth configs
-    docker compose run scripts write-geth-genesis-config
+    run_script write-geth-genesis-config
 
     if $consensusclient; then
       echo == Writing prysm configs
-      docker compose run scripts write-prysm-config
+      run_script write-prysm-config
 
       echo == Creating prysm genesis
       docker compose run create_beacon_chain_genesis
@@ -464,29 +468,29 @@ if $force_init; then
     docker compose up --wait geth
 
     echo == Waiting for geth to sync
-    docker compose run scripts wait-for-sync --url http://geth:8545
+    run_script wait-for-sync --url http://geth:8545
 
     echo == Funding validator, sequencer and l2owner
-    docker compose run scripts send-l1 --ethamount 1000 --to validator --wait
-    docker compose run scripts send-l1 --ethamount 1000 --to sequencer --wait
-    docker compose run scripts send-l1 --ethamount 1000 --to l2owner --wait
+    run_script send-l1 --ethamount 1000 --to validator --wait
+    run_script send-l1 --ethamount 1000 --to sequencer --wait
+    run_script send-l1 --ethamount 1000 --to l2owner --wait
 
     echo == create l1 traffic
-    docker compose run scripts send-l1 --ethamount 1000 --to user_l1user --wait
-    docker compose run scripts send-l1 --ethamount 0.0001 --from user_l1user --to user_l1user --wait --delay 1000 --times 1000000 > /dev/null &
+    run_script send-l1 --ethamount 1000 --to user_l1user --wait
+    run_script send-l1 --ethamount 0.0001 --from user_l1user --to user_l1user --wait --delay 1000 --times 1000000 > /dev/null &
 
-    l2ownerAddress=`docker compose run scripts print-address --account l2owner | tail -n 1 | tr -d '\r\n'`
+    l2ownerAddress=`run_script print-address --account l2owner | tail -n 1 | tr -d '\r\n'`
 
     if $l2anytrust; then
         echo "== Writing l2 chain config (anytrust enabled)"
-        docker compose run scripts --l2owner $l2ownerAddress  write-l2-chain-config --anytrust
+        run_script --l2owner $l2ownerAddress  write-l2-chain-config --anytrust
     else
         echo == Writing l2 chain config
-        docker compose run scripts --l2owner $l2ownerAddress  write-l2-chain-config
+        run_script --l2owner $l2ownerAddress  write-l2-chain-config
     fi
 
-    sequenceraddress=`docker compose run scripts print-address --account sequencer | tail -n 1 | tr -d '\r\n'`
-    l2ownerKey=`docker compose run scripts print-private-key --account l2owner | tail -n 1 | tr -d '\r\n'`
+    sequenceraddress=`run_script print-address --account sequencer | tail -n 1 | tr -d '\r\n'`
+    l2ownerKey=`run_script print-private-key --account l2owner | tail -n 1 | tr -d '\r\n'`
     wasmroot=`docker compose run --entrypoint sh sequencer -c "cat /home/user/target/machines/latest/module-root.txt"`
 
     echo == Deploying L2 chain
@@ -510,15 +514,15 @@ if $l2anytrust; then
         docker compose run --user root --entrypoint sh datool -c "chown -R 1000:1000 /das*"
         docker compose run datool keygen --dir /das-committee-a/keys
         docker compose run datool keygen --dir /das-committee-b/keys
-        docker compose run scripts write-l2-das-committee-config
-        docker compose run scripts write-l2-das-mirror-config
+        run_script write-l2-das-committee-config
+        run_script write-l2-das-mirror-config
 
         das_bls_a=`docker compose run --entrypoint sh datool -c "cat /das-committee-a/keys/das_bls.pub"`
         das_bls_b=`docker compose run --entrypoint sh datool -c "cat /das-committee-b/keys/das_bls.pub"`
 
-        docker compose run scripts write-l2-das-keyset-config --dasBlsA $das_bls_a --dasBlsB $das_bls_b
+        run_script write-l2-das-keyset-config --dasBlsA $das_bls_a --dasBlsB $das_bls_b
         docker compose run --entrypoint sh datool -c "/usr/local/bin/datool dumpkeyset --conf.file /config/l2_das_keyset.json | grep 'Keyset: ' | awk '{ printf \"%s\", \$2 }' > /config/l2_das_keyset.hex"
-        docker compose run scripts set-valid-keyset
+        run_script set-valid-keyset
 
         anytrustNodeConfigLine="--anytrust --dasBlsA $das_bls_a --dasBlsB $das_bls_b"
     fi
@@ -535,37 +539,37 @@ if $force_init; then
     fi
     if $simple; then
         echo == Writing configs
-        docker compose run scripts write-config --simple $anytrustNodeConfigLine $timeboostNodeConfigLine
+        run_script write-config --simple $anytrustNodeConfigLine $timeboostNodeConfigLine
     else
         echo == Writing configs
-        docker compose run scripts write-config $anytrustNodeConfigLine $timeboostNodeConfigLine
+        run_script write-config $anytrustNodeConfigLine $timeboostNodeConfigLine
 
         echo == Initializing redis
         docker compose up --wait redis
-        docker compose run scripts redis-init --redundancy $redundantsequencers
+        run_script redis-init --redundancy $redundantsequencers
     fi
 
     echo == Funding l2 funnel and dev key
     docker compose up --wait $INITIAL_SEQ_NODES
-    docker compose run scripts bridge-funds --ethamount 100000 --wait
-    docker compose run scripts send-l2 --ethamount 100 --to l2owner --wait
+    run_script bridge-funds --ethamount 100000 --wait
+    run_script send-l2 --ethamount 100 --to l2owner --wait
     rollupAddress=`docker compose run --entrypoint sh poster -c "jq -r '.[0].rollup.rollup' /config/deployed_chain_info.json | tail -n 1 | tr -d '\r\n'"`
 
     if $l2timeboost; then
-        docker compose run scripts send-l2 --ethamount 100 --to auctioneer --wait
-        biddingTokenAddress=`docker compose run scripts create-erc20 --deployer auctioneer | tail -n 1 | awk '{ print $NF }'`
-        auctionContractAddress=`docker compose run scripts deploy-express-lane-auction --bidding-token $biddingTokenAddress | tail -n 1 | awk '{ print $NF }'`
-        auctioneerAddress=`docker compose run scripts print-address --account auctioneer | tail -n1 | tr -d '\r\n'`
+        run_script send-l2 --ethamount 100 --to auctioneer --wait
+        biddingTokenAddress=`run_script create-erc20 --deployer auctioneer | tail -n 1 | awk '{ print $NF }'`
+        auctionContractAddress=`run_script deploy-express-lane-auction --bidding-token $biddingTokenAddress | tail -n 1 | awk '{ print $NF }'`
+        auctioneerAddress=`run_script print-address --account auctioneer | tail -n1 | tr -d '\r\n'`
         echo == Starting up Timeboost auctioneer and bid validator.
         echo == Bidding token: $biddingTokenAddress, auction contract $auctionContractAddress
-        docker compose run scripts write-timeboost-configs --auction-contract $auctionContractAddress
+        run_script write-timeboost-configs --auction-contract $auctionContractAddress
         docker compose run --user root --entrypoint sh timeboost-auctioneer -c "chown -R 1000:1000 /data"
 
         echo == Funding alice and bob user accounts for timeboost testing
-        docker compose run scripts send-l2 --ethamount 10 --to user_alice --wait
-        docker compose run scripts send-l2 --ethamount 10 --to user_bob --wait
-        docker compose run scripts transfer-erc20 --token $biddingTokenAddress --amount 10000 --from auctioneer --to user_alice
-        docker compose run scripts transfer-erc20 --token $biddingTokenAddress --amount 10000 --from auctioneer --to user_bob
+        run_script send-l2 --ethamount 10 --to user_alice --wait
+        run_script send-l2 --ethamount 10 --to user_bob --wait
+        run_script transfer-erc20 --token $biddingTokenAddress --amount 10000 --from auctioneer --to user_alice
+        run_script transfer-erc20 --token $biddingTokenAddress --amount 10000 --from auctioneer --to user_bob
 
         docker compose run --entrypoint sh scripts -c "sed -i 's/\(\"execution\":{\"sequencer\":{\"enable\":true,\"dangerous\":{\"timeboost\":{\"enable\":\)false/\1true,\"auction-contract-address\":\"$auctionContractAddress\",\"auctioneer-address\":\"$auctioneerAddress\"/' /config/sequencer_config.json" --wait
         docker compose restart $INITIAL_SEQ_NODES
@@ -583,53 +587,53 @@ if $force_init; then
     docker compose run -e CHILD_CHAIN_RPC="http://sequencer:8547" -e CHAIN_OWNER_PRIVKEY=$l2ownerKey rollupcreator deploy-cachemanager-testnode
 
     echo == Deploy Stylus Deployer on L2
-    docker compose run scripts create-stylus-deployer --deployer l2owner
+    run_script create-stylus-deployer --deployer l2owner
 
     # TODO: remove this once the gas estimation issue is fixed
     echo == Gas Estimation workaround
-    docker compose run scripts send-l1 --ethamount 1 --to address_0x0000000000000000000000000000000000000000 --wait
-    docker compose run scripts send-l2 --ethamount 1 --to address_0x0000000000000000000000000000000000000000 --wait
+    run_script send-l1 --ethamount 1 --to address_0x0000000000000000000000000000000000000000 --wait
+    run_script send-l2 --ethamount 1 --to address_0x0000000000000000000000000000000000000000 --wait
 
     if $l3node; then
         echo == Funding l3 users
-        docker compose run scripts send-l2 --ethamount 1000 --to validator --wait
-        docker compose run scripts send-l2 --ethamount 1000 --to l3owner --wait
-        docker compose run scripts send-l2 --ethamount 1000 --to l3sequencer --wait
+        run_script send-l2 --ethamount 1000 --to validator --wait
+        run_script send-l2 --ethamount 1000 --to l3owner --wait
+        run_script send-l2 --ethamount 1000 --to l3sequencer --wait
 
         echo == Funding l2 deployers
-        docker compose run scripts send-l1 --ethamount 100 --to user_token_bridge_deployer --wait
-        docker compose run scripts send-l2 --ethamount 100 --to user_token_bridge_deployer --wait
+        run_script send-l1 --ethamount 100 --to user_token_bridge_deployer --wait
+        run_script send-l2 --ethamount 100 --to user_token_bridge_deployer --wait
 
         echo == Funding token deployer
-        docker compose run scripts send-l1 --ethamount 100 --to user_fee_token_deployer --wait
-        docker compose run scripts send-l2 --ethamount 100 --to user_fee_token_deployer --wait
+        run_script send-l1 --ethamount 100 --to user_fee_token_deployer --wait
+        run_script send-l2 --ethamount 100 --to user_fee_token_deployer --wait
 
         echo == create l2 traffic
-        docker compose run scripts send-l2 --ethamount 100 --to user_traffic_generator --wait
-        docker compose run scripts send-l2 --ethamount 0.0001 --from user_traffic_generator --to user_traffic_generator --wait --delay 500 --times 1000000 > /dev/null &
+        run_script send-l2 --ethamount 100 --to user_traffic_generator --wait
+        run_script send-l2 --ethamount 0.0001 --from user_traffic_generator --to user_traffic_generator --wait --delay 500 --times 1000000 > /dev/null &
 
         echo == Writing l3 chain config
-        l3owneraddress=`docker compose run scripts print-address --account l3owner | tail -n 1 | tr -d '\r\n'`
+        l3owneraddress=`run_script print-address --account l3owner | tail -n 1 | tr -d '\r\n'`
         echo l3owneraddress $l3owneraddress
-        docker compose run scripts --l2owner $l3owneraddress  write-l3-chain-config
+        run_script --l2owner $l3owneraddress  write-l3-chain-config
 
         EXTRA_L3_DEPLOY_FLAG=""
         if $l3_custom_fee_token; then
             echo == Deploying custom fee token
-            nativeTokenAddress=`docker compose run scripts create-erc20 --deployer user_fee_token_deployer --bridgeable $tokenbridge --decimals $l3_custom_fee_token_decimals | tail -n 1 | awk '{ print $NF }'`
-            docker compose run scripts transfer-erc20 --token $nativeTokenAddress --amount 10000 --from user_fee_token_deployer --to l3owner
-            docker compose run scripts transfer-erc20 --token $nativeTokenAddress --amount 10000 --from user_fee_token_deployer --to user_token_bridge_deployer
+            nativeTokenAddress=`run_script create-erc20 --deployer user_fee_token_deployer --bridgeable $tokenbridge --decimals $l3_custom_fee_token_decimals | tail -n 1 | awk '{ print $NF }'`
+            run_script transfer-erc20 --token $nativeTokenAddress --amount 10000 --from user_fee_token_deployer --to l3owner
+            run_script transfer-erc20 --token $nativeTokenAddress --amount 10000 --from user_fee_token_deployer --to user_token_bridge_deployer
             EXTRA_L3_DEPLOY_FLAG="-e FEE_TOKEN_ADDRESS=$nativeTokenAddress"
             if $l3_custom_fee_token_pricer; then
                 echo == Deploying custom fee token pricer
-                feeTokenPricerAddress=`docker compose run scripts create-fee-token-pricer --deployer user_fee_token_deployer | tail -n 1 | awk '{ print $NF }'`
+                feeTokenPricerAddress=`run_script create-fee-token-pricer --deployer user_fee_token_deployer | tail -n 1 | awk '{ print $NF }'`
                 EXTRA_L3_DEPLOY_FLAG="$EXTRA_L3_DEPLOY_FLAG -e FEE_TOKEN_PRICER_ADDRESS=$feeTokenPricerAddress"
             fi
         fi
 
         echo == Deploying L3
-        l3ownerkey=`docker compose run scripts print-private-key --account l3owner | tail -n 1 | tr -d '\r\n'`
-        l3sequenceraddress=`docker compose run scripts print-address --account l3sequencer | tail -n 1 | tr -d '\r\n'`
+        l3ownerkey=`run_script print-private-key --account l3owner | tail -n 1 | tr -d '\r\n'`
+        l3sequenceraddress=`run_script print-address --account l3sequencer | tail -n 1 | tr -d '\r\n'`
 
         docker compose run -e DEPLOYER_PRIVKEY=$l3ownerkey -e PARENT_CHAIN_RPC="http://sequencer:8547" -e PARENT_CHAIN_ID=412346 -e CHILD_CHAIN_NAME="orbit-dev-test" -e MAX_DATA_SIZE=104857 -e OWNER_ADDRESS=$l3owneraddress -e WASM_MODULE_ROOT=$wasmroot -e SEQUENCER_ADDRESS=$l3sequenceraddress -e AUTHORIZE_VALIDATORS=10 -e CHILD_CHAIN_CONFIG_PATH="/config/l3_chain_config.json" -e CHAIN_DEPLOYMENT_INFO="/config/l3deployment.json" -e CHILD_CHAIN_INFO="/config/deployed_l3_chain_info.json" $EXTRA_L3_DEPLOY_FLAG rollupcreator create-rollup-testnode
         docker compose run --entrypoint sh rollupcreator -c "jq [.[]] /config/deployed_l3_chain_info.json > /config/l3_chain_info.json"
@@ -653,28 +657,28 @@ if $force_init; then
             # set L3 UpgradeExecutor, deployed by token bridge creator in previous step, to be the L3 chain owner. L3owner (EOA) and alias of L2 UpgradeExectuor have the executor role on the L3 UpgradeExecutor
             echo == Set L3 UpgradeExecutor to be chain owner
             tokenBridgeCreator=`docker compose run --entrypoint sh tokenbridge -c "cat l2l3_network.json" | jq -r '.l1TokenBridgeCreator'`
-            docker compose run scripts transfer-l3-chain-ownership --creator $tokenBridgeCreator
+            run_script transfer-l3-chain-ownership --creator $tokenBridgeCreator
             echo
         fi
 
         echo == Fund L3 accounts
         if $l3_custom_fee_token; then
-            docker compose run scripts bridge-native-token-to-l3 --amount 5000 --from user_fee_token_deployer --wait
-            docker compose run scripts send-l3 --ethamount 100 --from user_fee_token_deployer --wait
+            run_script bridge-native-token-to-l3 --amount 5000 --from user_fee_token_deployer --wait
+            run_script send-l3 --ethamount 100 --from user_fee_token_deployer --wait
         else
-            docker compose run scripts bridge-to-l3 --ethamount 50000 --wait
+            run_script bridge-to-l3 --ethamount 50000 --wait
         fi
-        docker compose run scripts send-l3 --ethamount 10 --to l3owner --wait
+        run_script send-l3 --ethamount 10 --to l3owner --wait
 
         echo == Deploy CacheManager on L3
         docker compose run -e CHILD_CHAIN_RPC="http://l3node:3347" -e CHAIN_OWNER_PRIVKEY=$l3ownerkey rollupcreator deploy-cachemanager-testnode
 
         echo == Deploy Stylus Deployer on L3
-        docker compose run scripts create-stylus-deployer --deployer l3owner --l3
+        run_script create-stylus-deployer --deployer l3owner --l3
 
         echo == create l3 traffic
-        docker compose run scripts send-l3 --ethamount 10 --to user_traffic_generator --wait
-        docker compose run scripts send-l3 --ethamount 0.0001 --from user_traffic_generator --to user_traffic_generator --wait --delay 5000 --times 1000000 > /dev/null &
+        run_script send-l3 --ethamount 10 --to user_traffic_generator --wait
+        run_script send-l3 --ethamount 0.0001 --from user_traffic_generator --to user_traffic_generator --wait --delay 5000 --times 1000000 > /dev/null &
     fi
 fi
 


### PR DESCRIPTION
Running `./test-node.bash` creates a ton of auxiliary containers (used for one-shot actions, like config preparation). Unfortunately, the script doesn't remove then which:
1. pollutes docker space with lots of dead containers
2. pollutes logs with warnings like:
```
WARN[0000] Found orphan containers ([
  nitro-testnode-sequencer-run-747910b47e23 
  nitro-testnode-scripts-run-a08522fda575 
  nitro-testnode-scripts-run-2a91f046f22d 
  nitro-testnode-scripts-run-5b115e3e3314 
  nitro-testnode-scripts-run-e64f5b255be4 
  nitro-testnode-scripts-run-e5088e1ff316 
  nitro-testnode-scripts-run-4e3216118797 
  nitro-testnode-scripts-run-8b6c8e986018 
  nitro-testnode-scripts-run-29373b8e250c 
  nitro-testnode-scripts-run-dacd378e0a35 
  nitro-testnode-geth-run-571b194062a0 
  nitro-testnode-scripts-run-6846cac9f10b 
  nitro-testnode-geth-run-81bfa8f691a0 
  nitro-testnode-geth-run-0d06d27138fc 
  nitro-testnode-geth-run-ead58fbb8d7e 
  nitro-testnode-scripts-run-b06e3e8f486b
]) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up. 
```

Generalizes https://github.com/OffchainLabs/nitro-testnode/pull/147
Closes NIT-3941

before:
<img width="847" height="1226" alt="image" src="https://github.com/user-attachments/assets/4bca0bde-5300-4de1-86e9-369d70542bd8" />

after:
<img width="820" height="453" alt="image" src="https://github.com/user-attachments/assets/2d3794b7-59f1-4eb2-9cf5-ba436224c6ba" />
