### PR TITLE
Update address filter hashing to match provider spec - NIT-4754

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -492,7 +492,7 @@ services:
       MINIO_ROOT_PASSWORD: minioadmin
     command: server /data --console-address ":9001"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      test: ["CMD", "mc", "ready", "local"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -873,7 +873,7 @@ export const initTxFilteringMinioCommand = {
     command: "init-tx-filtering-minio",
     describe: "initializes MinIO bucket and empty address hash list",
     handler: async () => {
-        const salt = crypto.randomBytes(32).toString('hex');
+        const salt = crypto.randomUUID();
         const initialAddressList = {
             "salt": salt,
             "hashing_scheme": "Sha256",
@@ -902,9 +902,9 @@ export const initTxFilteringMinioCommand = {
 }
 
 function computeAddressHash(address: string, salt: string): string {
-    const normalizedAddress = address.toLowerCase();
-    const data = salt + normalizedAddress.replace('0x', '');
-    const hash = crypto.createHash('sha256').update(Buffer.from(data, 'hex')).digest('hex');
+    const normalizedAddress = address.toLowerCase().replace('0x', '');
+    const hashInput = salt + '::0x' + normalizedAddress;
+    const hash = crypto.createHash('sha256').update(hashInput).digest('hex');
     return hash;
 }
 


### PR DESCRIPTION
  ## Summary
  - Update hashing algorithm in `scripts/config.ts` to match [nitro#4586](https://github.com/OffchainLabs/nitro/pull/4586)
  - Salt generation changed from random hex bytes to UUID (`crypto.randomUUID()`)
  - Hash input changed from binary `SHA256(salt_bytes + addr_bytes)` to string `SHA256("{uuid}::0x{address}")`
  - Fix MinIO healthcheck in `docker-compose.yaml` (`curl` → `mc ready local`)

  ## Testing
  - Verified hash output matches the Go implementation using known test vector (salt: `3ccf0cbf-...`, address: `0xddfAbCdc...`, expected hash: `0x8fb74f22...`)
  - Full E2E test: started testnode with `--l2-tx-filtering`, added address to filter list, confirmed tx was rejected, removed address, confirmed tx succeeded again