### PR TITLE
Minor change to how docker cleans up resources

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
       - postgres
       - sequencer
     image: blockscout-testnode
-    restart: always
+    restart: unless-stopped
     container_name: 'blockscout'
     links:
       - postgres:database
@@ -30,7 +30,7 @@ services:
 
   postgres:
     image: postgres:13.6
-    restart: always
+    restart: unless-stopped
     container_name: 'postgres'
     environment:
         POSTGRES_PASSWORD: ''

--- a/test-node.bash
+++ b/test-node.bash
@@ -461,15 +461,15 @@ fi
 
 if $force_init; then
     echo == Removing old data..
-    docker compose down
+    docker compose down --remove-orphans --timeout 10 2>/dev/null || true
     leftoverContainers=`docker container ls -a --filter label=com.docker.compose.project=nitro-testnode -q | xargs echo`
     if [ `echo $leftoverContainers | wc -w` -gt 0 ]; then
-        docker rm $leftoverContainers
+        docker rm -f $leftoverContainers
     fi
     docker volume prune -f --filter label=com.docker.compose.project=nitro-testnode
     leftoverVolumes=`docker volume ls --filter label=com.docker.compose.project=nitro-testnode -q | xargs echo`
     if [ `echo $leftoverVolumes | wc -w` -gt 0 ]; then
-        docker volume rm $leftoverVolumes
+        docker volume rm -f $leftoverVolumes
     fi
 
     echo == Generating l1 keys


### PR DESCRIPTION
I had claude do some analysis on our docker usage and here is what it found:

Now I have a clear picture. Here's my analysis and fix:

  Analysis

  The error occurs during --init cleanup at lines 462-467 of test-node.bash. The root cause is a race condition:

  1. docker compose down sends SIGTERM to containers and tries to remove them and the network
  2. blockscout and postgres have restart: always — Docker restarts them immediately after they're stopped, so they're still running when docker compose down tries to remove the network
  3. The subsequent docker rm on line 467 also fails because these containers restarted and are running

  The fix has two parts:

  1. Use docker compose down --remove-orphans --timeout 10 to give containers time and clean up orphans.

  2. Change the leftover container cleanup to force-remove (docker rm -f), since any container still alive at this point is one that down couldn't stop (due to restart policy) and needs to
   be killed.

⏺ Update(test-node.bash)
  ⎿  Added 3 lines, removed 3 lines
      464 -    docker compose down                                                                                                                                                   
      464 +    docker compose down --remove-orphans --timeout 10 2>/dev/null || true                                                                                                 

      467 -        docker rm $leftoverContainers                                                                                                                                     
      467 +        docker rm -f $leftoverContainers                                                                                                                                  

      472 -        docker volume rm $leftoverVolumes                                                                                                                                 
      472 +        docker volume rm -f $leftoverVolumes                                                                                                                              

⏺ Now change restart: always to restart: unless-stopped for blockscout and postgres. This prevents them from restarting during a docker compose down while still auto-restarting on crashes
  during normal operation.

⏺ Update(docker-compose.yaml)
  ⎿  Added 1 line, removed 1 line
       6      image: blockscout-testnode
       7 -    restart: always                                                                                                                                                        
       7 +    restart: unless-stopped                                                                                                                                                


⏺ Update(docker-compose.yaml)
  ⎿  Added 1 line, removed 1 line
      30  
      31    postgres:
      32      image: postgres:13.6
      33 -    restart: always                                                                                                                                                        
      33 +    restart: unless-stopped                                                                                                                                                

⏺ Summary of changes

  Root cause: restart: always on blockscout and postgres causes Docker to restart them immediately after docker compose down sends SIGTERM, so the containers are running again when the
  script tries to remove them and the network.

  Changes made:

  1. docker-compose.yaml — Changed restart: always to restart: unless-stopped for both blockscout and postgres. This preserves auto-restart during normal operation (crash recovery) but
  allows docker compose down / docker stop to stop them permanently without restart.
  2. test-node.bash (init cleanup block):
    - Added --remove-orphans --timeout 10 to docker compose down — cleans up orphaned containers and gives services 10 seconds for graceful shutdown
    - Added 2>/dev/null || true so a partial failure in down doesn't abort the script (the subsequent force-remove handles stragglers)
    - Changed docker rm to docker rm -f — force-kills any leftover containers that survived down (e.g., from a previous interrupted run)
    - Changed docker volume rm to docker volume rm -f — same defensive approach for volumes still referenced by dying containers