### PR TITLE
Prepare nitro-test node for txn filter reporting feature - NIT-4675

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -536,7 +536,6 @@ services:
       - --conf.file=/config/filtering_report_config.json
     depends_on:
       - elasticmq
-      - sequencer
 
   report-receiver:
     build: scripts/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -511,6 +511,39 @@ services:
     depends_on:
       - sequencer
 
+  elasticmq:
+    image: softwaremill/elasticmq-native:1.6.9
+    ports:
+      - "127.0.0.1:9324:9324"
+    volumes:
+      - "config:/config"
+    command: ["-Dconfig.file=/config/elasticmq.conf"]
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:9325 || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  filtering-report:
+    pid: host
+    image: nitro-node-dev-testnode
+    entrypoint: /usr/local/bin/filtering-report
+    ports:
+      - "127.0.0.1:8550:8547"
+    volumes:
+      - "config:/config"
+    command:
+      - --conf.file=/config/filtering_report_config.json
+    depends_on:
+      - elasticmq
+      - sequencer
+
+  report-receiver:
+    build: scripts/
+    command: ["serve-report-receiver"]
+    ports:
+      - "127.0.0.1:9081:8080"
+
 volumes:
   l1data:
   consensus:

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -211,7 +211,7 @@ function createDataAvailabilityConfig(argv: any, anytrust: boolean) {
 }
 
 function applyTxFilteringConfig(config: any) {
-    config.execution.sequencer["transaction-filtering"] = {
+    config.execution["transaction-filtering"] = {
         "address-filter": {
             "enable": true,
             "s3": {
@@ -387,6 +387,9 @@ function writeConfigs(argv: any) {
         if (argv.txfiltering) {
             applyTxFilteringConfig(simpleConfig);
         }
+        if (argv.filteringreport) {
+            applyFilteringReportConfig(simpleConfig);
+        }
         fs.writeFileSync(path.join(consts.configpath, "sequencer_config.json"), JSON.stringify(simpleConfig))
     } else {
         let validatorConfig = JSON.parse(baseConfJSON)
@@ -412,6 +415,9 @@ function writeConfigs(argv: any) {
         }
         if (argv.txfiltering) {
             applyTxFilteringConfig(sequencerConfig);
+        }
+        if (argv.filteringreport) {
+            applyFilteringReportConfig(sequencerConfig);
         }
         fs.writeFileSync(path.join(consts.configpath, "sequencer_config.json"), JSON.stringify(sequencerConfig))
 
@@ -740,6 +746,11 @@ export const writeConfigCommand = {
             describe: "enable transaction filtering mode",
             default: false
         },
+        filteringreport: {
+            boolean: true,
+            describe: "enable filtering report framework",
+            default: false
+        },
     },
     handler: (argv: any) => {
         writeConfigs(argv)
@@ -873,8 +884,10 @@ export const initTxFilteringMinioCommand = {
     command: "init-tx-filtering-minio",
     describe: "initializes MinIO bucket and empty address hash list",
     handler: async () => {
+        const id = crypto.randomUUID();
         const salt = crypto.randomUUID();
         const initialAddressList = {
+            "id": id,
             "salt": salt,
             "hashing_scheme": "Sha256",
             "address_hashes": []
@@ -1012,5 +1025,133 @@ export const removeFilteredAddressCommand = {
         } else {
             console.log("Address hash not in list:", hash);
         }
+    }
+}
+
+function writeElasticMQConfig() {
+    const elasticmqConf = `include classpath("application.conf")
+
+node-address {
+  protocol = http
+  host = "*"
+  port = 9324
+  context-path = ""
+}
+
+rest-sqs {
+  enabled = true
+  bind-port = 9324
+  bind-hostname = "0.0.0.0"
+  sqs-limits = strict
+}
+
+queues {
+  filtering-reports {
+    defaultVisibilityTimeout = 30 seconds
+    delay = 0 seconds
+    receiveMessageWait = 0 seconds
+  }
+}
+`;
+    fs.writeFileSync(path.join(consts.configpath, "elasticmq.conf"), elasticmqConf);
+}
+
+export const writeElasticMQConfigCommand = {
+    command: "write-elasticmq-config",
+    describe: "writes ElasticMQ config file for SQS emulation",
+    handler: () => {
+        writeElasticMQConfig();
+    }
+}
+
+function writeFilteringReportConfig() {
+    const config = {
+        "http": {
+            "addr": "0.0.0.0",
+            "port": 8547,
+            "vhosts": "*",
+            "corsdomain": "*",
+            "api": ["filteringreport"]
+        },
+        "ws": {
+            "addr": "0.0.0.0",
+            "port": 8548
+        },
+        "queue": {
+            "queue-url": "http://elasticmq:9324/000000000000/filtering-reports",
+            "sqs-client": {
+                "region": "us-east-1",
+                "endpoint": "http://elasticmq:9324",
+                "access-key": "elasticmq",
+                "secret-key": "elasticmq"
+            }
+        },
+        "report-forwarder": {
+            "workers": 1,
+            "poll-interval": "5s",
+            "sqs-wait-time-seconds": 5,
+            "external-endpoint": {
+                "url": "http://report-receiver:8080",
+                "timeout": "10s"
+            }
+        }
+    };
+    fs.writeFileSync(
+        path.join(consts.configpath, "filtering_report_config.json"),
+        JSON.stringify(config)
+    );
+}
+
+export const writeFilteringReportConfigCommand = {
+    command: "write-filtering-report-config",
+    describe: "writes filtering-report service config file",
+    handler: () => {
+        writeFilteringReportConfig();
+    }
+}
+
+function applyFilteringReportConfig(config: any) {
+    if (!config.execution["transaction-filtering"]) {
+        config.execution["transaction-filtering"] = {};
+    }
+    config.execution["transaction-filtering"]["filtering-report-rpc-client"] = {
+        "url": "http://filtering-report:8547"
+    };
+}
+
+export const serveReportReceiverCommand = {
+    command: "serve-report-receiver",
+    describe: "starts an HTTP server that receives and logs filtering reports",
+    handler: async () => {
+        const http = require('http');
+        const reports: any[] = [];
+        const server = http.createServer((req: any, res: any) => {
+            if (req.method === 'POST') {
+                let body = '';
+                req.on('data', (chunk: string) => body += chunk);
+                req.on('end', () => {
+                    console.log('Received report:', body);
+                    reports.push(JSON.parse(body));
+                    res.writeHead(200, {'Content-Type': 'application/json'});
+                    res.end(JSON.stringify({status: 'ok'}));
+                });
+            } else if (req.method === 'GET' && req.url === '/reports') {
+                res.writeHead(200, {'Content-Type': 'application/json'});
+                res.end(JSON.stringify(reports));
+            } else {
+                res.writeHead(200);
+                res.end('OK');
+            }
+        });
+        server.listen(8080, '0.0.0.0', () => {
+            console.log('Report receiver listening on :8080');
+        });
+        // Handler must be async and await a never-resolving promise so yargs
+        // does not return early. Without this, index.ts's
+        // `main().then(() => process.exit(0))` would terminate the process
+        // immediately after server.listen() starts, killing the server.
+        // SIGINT / SIGTERM from `docker compose down` will still terminate
+        // the container cleanly.
+        await new Promise<void>(() => {});
     }
 }

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -753,6 +753,9 @@ export const writeConfigCommand = {
         },
     },
     handler: (argv: any) => {
+        if (argv.filteringreport) {
+            argv.txfiltering = true;
+        }
         writeConfigs(argv)
     }
 }
@@ -1131,9 +1134,15 @@ export const serveReportReceiverCommand = {
                 req.on('data', (chunk: string) => body += chunk);
                 req.on('end', () => {
                     console.log('Received report:', body);
-                    reports.push(JSON.parse(body));
-                    res.writeHead(200, {'Content-Type': 'application/json'});
-                    res.end(JSON.stringify({status: 'ok'}));
+                    try {
+                        reports.push(JSON.parse(body));
+                        res.writeHead(200, {'Content-Type': 'application/json'});
+                        res.end(JSON.stringify({status: 'ok'}));
+                    } catch (err) {
+                        console.error('Failed to parse report body:', err);
+                        res.writeHead(400, {'Content-Type': 'application/json'});
+                        res.end(JSON.stringify({status: 'error', message: 'invalid JSON'}));
+                    }
                 });
             } else if (req.method === 'GET' && req.url === '/reports') {
                 res.writeHead(200, {'Content-Type': 'application/json'});

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -18,6 +18,9 @@ import {
   hashAddressCommand,
   addFilteredAddressCommand,
   removeFilteredAddressCommand,
+  writeElasticMQConfigCommand,
+  writeFilteringReportConfigCommand,
+  serveReportReceiverCommand,
 } from "./config";
 import {
   printAddressCommand,
@@ -88,6 +91,9 @@ async function main() {
     .command(hashAddressCommand)
     .command(addFilteredAddressCommand)
     .command(removeFilteredAddressCommand)
+    .command(writeElasticMQConfigCommand)
+    .command(writeFilteringReportConfigCommand)
+    .command(serveReportReceiverCommand)
     .command(grantFiltererRoleCommand)
     .command(printAddressCommand)
     .command(printPrivateKeyCommand)
@@ -97,7 +103,8 @@ async function main() {
     .strict()
     .demandCommand(1, "a command must be specified")
     .epilogue(namedAccountHelpString)
-    .help().argv;
+    .help()
+    .parseAsync();
 }
 
 main()

--- a/test-node.bash
+++ b/test-node.bash
@@ -63,6 +63,7 @@ l2anytrust=false
 l2referenceda=false
 l2timeboost=false
 l2txfiltering=false
+l2filteringreport=false
 
 # Use the dev versions of nitro/blockscout
 dev_nitro=false
@@ -280,6 +281,11 @@ while [[ $# -gt 0 ]]; do
             l2txfiltering=true
             shift
             ;;
+        --l2-filtering-report)
+            l2filteringreport=true
+            l2txfiltering=true
+            shift
+            ;;
         --redundantsequencers)
             simple=false
             redundantsequencers=$2
@@ -326,6 +332,7 @@ while [[ $# -gt 0 ]]; do
             echo --l2-referenceda  run the L2 with reference external data availability provider
             echo --l2-timeboost    run the L2 with Timeboost enabled, including auctioneer and bid validator
             echo --l2-tx-filtering  run the L2 with transaction filtering enabled
+            echo --l2-filtering-report  run the L2 with filtering report framework enabled \(implies --l2-tx-filtering\)
             echo --batchposters    batch posters [0-3]
             echo --redundantsequencers redundant sequencers [0-3]
             echo --detach          detach from nodes after running them
@@ -400,6 +407,10 @@ fi
 
 if $l2txfiltering; then
     NODES="$NODES minio transaction-filterer"
+fi
+
+if $l2filteringreport; then
+    NODES="$NODES elasticmq filtering-report report-receiver"
 fi
 
 if $dev_nitro && $build_dev_nitro; then
@@ -512,6 +523,14 @@ if $force_init; then
         run_script init-tx-filtering-minio
     fi
 
+    if $l2filteringreport; then
+        echo == Writing ElasticMQ config
+        run_script write-elasticmq-config
+
+        echo == Starting ElasticMQ
+        docker compose up --wait elasticmq
+    fi
+
     echo == Funding validator, sequencer and l2owner
     run_script send-l1 --ethamount 1000 --to validator --wait
     run_script send-l1 --ethamount 1000 --to sequencer --wait
@@ -568,6 +587,7 @@ anytrustNodeConfigLine=""
 referenceDaNodeConfigLine=""
 timeboostNodeConfigLine=""
 txFilteringNodeConfigLine=""
+filteringReportNodeConfigLine=""
 
 # Remaining init may require AnyTrust committee/mirrors to have been started
 if $l2anytrust; then
@@ -611,12 +631,15 @@ if $force_init; then
     if $l2txfiltering; then
         txFilteringNodeConfigLine="--txfiltering"
     fi
+    if $l2filteringreport; then
+        filteringReportNodeConfigLine="--filteringreport"
+    fi
 
     echo "== Writing configs"
     if $simple; then
-        run_script write-config --simple $anytrustNodeConfigLine $referenceDaNodeConfigLine $timeboostNodeConfigLine $txFilteringNodeConfigLine
+        run_script write-config --simple $anytrustNodeConfigLine $referenceDaNodeConfigLine $timeboostNodeConfigLine $txFilteringNodeConfigLine $filteringReportNodeConfigLine
     else
-        run_script write-config $anytrustNodeConfigLine $referenceDaNodeConfigLine $timeboostNodeConfigLine $txFilteringNodeConfigLine
+        run_script write-config $anytrustNodeConfigLine $referenceDaNodeConfigLine $timeboostNodeConfigLine $txFilteringNodeConfigLine $filteringReportNodeConfigLine
 
         echo == Initializing redis
         docker compose up --wait redis
@@ -659,6 +682,14 @@ if $force_init; then
 
         echo == Writing transaction-filterer service config
         run_script write-tx-filterer-config
+    fi
+
+    if $l2filteringreport; then
+        echo == Starting report receiver
+        docker compose up --wait report-receiver
+
+        echo == Writing filtering-report service config
+        run_script write-filtering-report-config
     fi
 
     if $tokenbridge; then


### PR DESCRIPTION
closes NIT-4675
### Test Plan Preperation
1- disabled eth-call filtering
2- Merged this [PR](https://github.com/OffchainLabs/nitro/pull/4620) with this [PR](https://github.com/OffchainLabs/nitro/pull/4627) locally as nitro-test base.

### Test procedure done 1
1- Prepared alice account with 1eth
2- Send to bob without filtering added.
= Expected result pass (validated)

### test procedure done 2
2- Add alice to filtered address
3- Send to Bob
= Transaction failed with error.
= Report receiver container received the full report.
Here was the container logs for report receiver:
```
Report receiver listening on :8080


Received report: {"id":"019d91c4-21d7-73f9-aad1-1ce1516300d0",
"txHash":"0xdd2ebc598e5ca044f7a2159aef4441a1a65cedd81652a32567efc196192589fc",
"txRLP":"0x02f87483064aba018459682f00846553f100825208942eb27d9f51d90c45ea735ee3b68e9be4ae2ab61f87038d7ea4c6800080c080a069bc4ddb895b24fcf29c67073cd8d215c8f2ca5e9edbc86be52119b9cf82a889a073911ab135d27c98a4de29931c43d3d6175e5d860c9d7ac7d098d0f223086ec1",
"filteredAddresses" [{"address":"0xc3c76aaaa7c483c5099aec225ba5e4269373f16b",
"reason":"from"}],"blockNumber":2373,
"parentBlockHash":"0xd851fcd18999de155c6a7564de1ed0df9ce9c11b8d0ff57351cd676c4cb7aa73","positionInBlock":1,"filteredAt":"2026-04-15T15:30:43.287261635Z","isDelayed":false}
```