### PR TITLE
Update address-filter JSON format and fix transaction-filtering config path

### DIFF
--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -211,7 +211,7 @@ function createDataAvailabilityConfig(argv: any, anytrust: boolean) {
 }
 
 function applyTxFilteringConfig(config: any) {
-    config.execution.sequencer["transaction-filtering"] = {
+    config.execution["transaction-filtering"] = {
         "address-filter": {
             "enable": true,
             "s3": {

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -875,9 +875,12 @@ export const initTxFilteringMinioCommand = {
     handler: async () => {
         const salt = crypto.randomUUID();
         const initialAddressList = {
-            "salt": salt,
-            "hashing_scheme": "Sha256",
-            "address_hashes": []
+            id: crypto.randomUUID(),
+            extract_uuid: crypto.randomUUID(),
+            salt: salt,
+            issued_at: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+            hashing_scheme: "sha256-stringinput",
+            hashes: [] as string[],
         };
         fs.writeFileSync(path.join(consts.configpath, "initial_address_hashes.json"), JSON.stringify(initialAddressList, null, 2));
         fs.writeFileSync(path.join(consts.configpath, "tx_filtering_salt.hex"), salt);
@@ -965,18 +968,21 @@ export const addFilteredAddressCommand = {
         }
         const salt = fs.readFileSync(saltPath).toString().trim();
         const hash = computeAddressHash(argv.address, salt);
+        const hashWithPrefix = "0x" + hash;
 
         const addressListPath = path.join(consts.configpath, "initial_address_hashes.json");
         const addressList = JSON.parse(fs.readFileSync(addressListPath).toString());
 
-        const exists = addressList.address_hashes.some((entry: any) => entry.hash === hash);
-        if (!exists) {
-            addressList.address_hashes.push({ hash: hash });
+        if (!addressList.hashes.includes(hashWithPrefix)) {
+            addressList.hashes.push(hashWithPrefix);
+            addressList.id = crypto.randomUUID();
+            addressList.extract_uuid = crypto.randomUUID();
+            addressList.issued_at = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
             fs.writeFileSync(addressListPath, JSON.stringify(addressList, null, 2));
-            console.log("Added address hash:", hash);
+            console.log("Added address hash:", hashWithPrefix);
             await uploadFilteredAddressesToMinio();
         } else {
-            console.log("Address hash already in list:", hash);
+            console.log("Address hash already in list:", hashWithPrefix);
         }
     }
 }
@@ -999,18 +1005,22 @@ export const removeFilteredAddressCommand = {
         }
         const salt = fs.readFileSync(saltPath).toString().trim();
         const hash = computeAddressHash(argv.address, salt);
+        const hashWithPrefix = "0x" + hash;
 
         const addressListPath = path.join(consts.configpath, "initial_address_hashes.json");
         const addressList = JSON.parse(fs.readFileSync(addressListPath).toString());
 
-        const index = addressList.address_hashes.findIndex((entry: any) => entry.hash === hash);
+        const index = addressList.hashes.indexOf(hashWithPrefix);
         if (index > -1) {
-            addressList.address_hashes.splice(index, 1);
+            addressList.hashes.splice(index, 1);
+            addressList.id = crypto.randomUUID();
+            addressList.extract_uuid = crypto.randomUUID();
+            addressList.issued_at = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
             fs.writeFileSync(addressListPath, JSON.stringify(addressList, null, 2));
-            console.log("Removed address hash:", hash);
+            console.log("Removed address hash:", hashWithPrefix);
             await uploadFilteredAddressesToMinio();
         } else {
-            console.log("Address hash not in list:", hash);
+            console.log("Address hash not in list:", hashWithPrefix);
         }
     }
 }

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -971,6 +971,10 @@ export const addFilteredAddressCommand = {
         const hashWithPrefix = "0x" + hash;
 
         const addressListPath = path.join(consts.configpath, "initial_address_hashes.json");
+        if (!fs.existsSync(addressListPath)) {
+            console.error("Address hash list not found. Run init-tx-filtering-minio first.");
+            process.exit(1);
+        }
         const addressList = JSON.parse(fs.readFileSync(addressListPath).toString());
 
         if (!addressList.hashes.includes(hashWithPrefix)) {
@@ -1008,6 +1012,10 @@ export const removeFilteredAddressCommand = {
         const hashWithPrefix = "0x" + hash;
 
         const addressListPath = path.join(consts.configpath, "initial_address_hashes.json");
+        if (!fs.existsSync(addressListPath)) {
+            console.error("Address hash list not found. Run init-tx-filtering-minio first.");
+            process.exit(1);
+        }
         const addressList = JSON.parse(fs.readFileSync(addressListPath).toString());
 
         const index = addressList.hashes.indexOf(hashWithPrefix);


### PR DESCRIPTION
Resolves [NIT-4918](https://linear.app/offchain-labs/issue/NIT-4918/update-json-format-of-the-censored-addresses-file)

## Summary
- Update the file written by `init-tx-filtering-minio` / `add-filtered-address` / `remove-filtered-address` to match the canonical hashed-list shape: `{id, extract_uuid, salt, issued_at, hashing_scheme: "sha256-stringinput", hashes: ["0x<hex>", ...]}`. `id`, `extract_uuid`, and `issued_at` are regenerated on each add/remove since each upload is a freshly issued list.
- Move the `transaction-filtering` config key from `execution.sequencer` to `execution` so the node reads it from the location the sequencer actually looks at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)